### PR TITLE
Make path case insensitive and added HasOperations property on Document.

### DIFF
--- a/src/JsonPatch.Tests/JsonPatchDocumentTests.cs
+++ b/src/JsonPatch.Tests/JsonPatchDocumentTests.cs
@@ -25,6 +25,19 @@ namespace JsonPatch.Tests
             Assert.AreEqual(JsonPatchOperationType.add, patchDocument.Operations.Single().Operation);
         }
 
+        [TestMethod]
+        public void Add_ValidPath_SetsHasOperations()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<SimpleEntity>();
+
+            //Act
+            patchDocument.Add("Foo", "bar");
+
+            //Assert
+            Assert.IsTrue(patchDocument.HasOperations);
+        }
+
         [TestMethod, ExpectedException(typeof(JsonPatchParseException))]
         public void Add_InvalidPath_ThrowsJsonPatchParseException()
         {
@@ -53,6 +66,18 @@ namespace JsonPatch.Tests
             Assert.AreEqual(JsonPatchOperationType.remove, patchDocument.Operations.Single().Operation);
         }
 
+        public void Remove_ValidPath_SetsHasOperations()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<SimpleEntity>();
+
+            //Act
+            patchDocument.Remove("Foo");
+
+            //Assert
+            Assert.IsTrue(patchDocument.HasOperations);
+        }
+
         [TestMethod, ExpectedException(typeof(JsonPatchParseException))]
         public void Remove_InvalidPath_ThrowsJsonPatchParseException()
         {
@@ -79,6 +104,19 @@ namespace JsonPatch.Tests
             //Assert
             Assert.AreEqual(1, patchDocument.Operations.Count);
             Assert.AreEqual(JsonPatchOperationType.replace, patchDocument.Operations.Single().Operation);
+        }
+
+        [TestMethod]
+        public void Replace_ValidPath_SetsHasOperations()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<SimpleEntity>();
+
+            //Act
+            patchDocument.Replace("Foo", "bar");
+
+            //Assert
+            Assert.IsTrue(patchDocument.HasOperations);
         }
 
         [TestMethod, ExpectedException(typeof(JsonPatchParseException))]

--- a/src/JsonPatch.Tests/JsonPatchDocumentTests.cs
+++ b/src/JsonPatch.Tests/JsonPatchDocumentTests.cs
@@ -95,6 +95,19 @@ namespace JsonPatch.Tests
 
         #region JsonPatch ApplyUpdatesTo Tests
 
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void ApplyUpdate_ThrowsException_IfEntityNull()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<SimpleEntity>();
+            SimpleEntity entity = null;
+
+            //Act
+            patchDocument.Add("Foo", "bar");
+
+            patchDocument.ApplyUpdatesTo(entity);
+        }
+
         [TestMethod]
         public void ApplyUpdate_AddOperation_EntityUpdated()
         {

--- a/src/JsonPatch.Tests/PathHelperTests.cs
+++ b/src/JsonPatch.Tests/PathHelperTests.cs
@@ -112,10 +112,30 @@ namespace JsonPatch.Tests
         }
 
         [TestMethod]
+        public void IsPathValid_SimplePath_CaseInsensitive_ReturnsTrue()
+        {
+            //act
+            var isValid = PathHelper.IsPathValid(typeof(SimpleEntity), "/foo");
+
+            //assert
+            Assert.IsTrue(isValid);
+        }
+
+        [TestMethod]
         public void IsPathValid_ArrayPath_ReturnsTrue()
         {
             //act
             var isValid = PathHelper.IsPathValid(typeof(ArrayEntity), "/Foo/3");
+
+            //assert
+            Assert.IsTrue(isValid);
+        }
+
+        [TestMethod]
+        public void IsPathValid_ArrayPath_CaseInsensitive_ReturnsTrue()
+        {
+            //act
+            var isValid = PathHelper.IsPathValid(typeof(ArrayEntity), "/FOO/3");
 
             //assert
             Assert.IsTrue(isValid);
@@ -141,6 +161,16 @@ namespace JsonPatch.Tests
             Assert.IsTrue(isValid);
         }
 
+        [TestMethod]
+        public void IsPathValid_ChildPathOnArray_CaseInsensitive_ReturnsTrue()
+        {
+            //act
+            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/BaZ/1/FOO");
+
+            //assert
+            Assert.IsTrue(isValid);
+        }
+
 		[TestMethod]
 		public void IsPathValid_ChildPathOnList_ReturnsTrue()
 		{
@@ -152,10 +182,30 @@ namespace JsonPatch.Tests
 		}
 
         [TestMethod]
+        public void IsPathValid_ChildPathOnList_CaseInsensitive_ReturnsTrue()
+        {
+            //act
+            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/QUX/1/FOo");
+
+            //assert
+            Assert.IsTrue(isValid);
+        }
+
+        [TestMethod]
         public void IsPathValid_PathOnChildArray_ReturnsTrue()
         {
             //act
-            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/Foo/Foo/1");
+            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/foo/FOo/1");
+
+            //assert
+            Assert.IsTrue(isValid);
+        }
+
+        [TestMethod]
+        public void IsPathValid_PathOnChildArray_CaseInsensitive_ReturnsTrue()
+        {
+            //act
+            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/FOO/foo/1");
 
             //assert
             Assert.IsTrue(isValid);
@@ -182,6 +232,19 @@ namespace JsonPatch.Tests
 
             //act
             PathHelper.SetValueFromPath(typeof(SimpleEntity), "/Foo", entity, "New Value", JsonPatchOperationType.add);
+
+            //assert
+            Assert.AreEqual("New Value", entity.Foo);
+        }
+
+        [TestMethod]
+        public void SetValueFromPath_SimplePathAddValueToNull_CaseInsensitive_UpdatesValue()
+        {
+            //arrange
+            var entity = new SimpleEntity { };
+
+            //act
+            PathHelper.SetValueFromPath(typeof(SimpleEntity), "/foo", entity, "New Value", JsonPatchOperationType.add);
 
             //assert
             Assert.AreEqual("New Value", entity.Foo);
@@ -264,6 +327,23 @@ namespace JsonPatch.Tests
 
             //act
             PathHelper.SetValueFromPath(typeof(ArrayEntity), "/Foo/1", entity, "Element Two Updated", JsonPatchOperationType.replace);
+
+            //Assert
+            Assert.AreEqual("Element Two Updated", entity.Foo[1]);
+            Assert.AreEqual(2, entity.Foo.Length);
+        }
+
+        [TestMethod]
+        public void SetValueFromPath_ReplaceArrayValue_CaseInsensitive_UpdatesValue()
+        {
+            //Arrange
+            var entity = new ArrayEntity
+            {
+                Foo = new string[] { "Element One", "Element Two" }
+            };
+
+            //act
+            PathHelper.SetValueFromPath(typeof(ArrayEntity), "/FOO/1", entity, "Element Two Updated", JsonPatchOperationType.replace);
 
             //Assert
             Assert.AreEqual("Element Two Updated", entity.Foo[1]);
@@ -479,6 +559,21 @@ namespace JsonPatch.Tests
 
             //act
             PathHelper.SetValueFromPath(typeof(ComplexEntity), "/Foo/Foo", entity, new[]{"Element One", "Element Two"}, JsonPatchOperationType.add);
+
+            //assert
+            Assert.IsNotNull(entity.Foo);
+            Assert.IsNotNull(entity.Foo.Foo);
+            Assert.AreEqual(2, entity.Foo.Foo.Length);
+        }
+
+        [TestMethod]
+        public void SetValueFromPath_SetArrayAddValueToNull_CaseInsensitive_AddsValue()
+        {
+            //arrange
+            var entity = new ComplexEntity { };
+
+            //act
+            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/FOO/foo", entity, new[] { "Element One", "Element Two" }, JsonPatchOperationType.add);
 
             //assert
             Assert.IsNotNull(entity.Foo);

--- a/src/JsonPatch/JsonPatchDocument.cs
+++ b/src/JsonPatch/JsonPatchDocument.cs
@@ -10,58 +10,34 @@ namespace JsonPatch
 {
     public class JsonPatchDocument<TEntity> : IJsonPatchDocument where TEntity : class, new()
     {
-
         private List<JsonPatchOperation> _operations = new List<JsonPatchOperation>();
 
         public List<JsonPatchOperation> Operations { get { return _operations; } }
 
+        public bool HasOperations { get { return _operations.Count > 0; } }
+
         public void Add(string path, object value)
         {
-            if (!PathHelper.IsPathValid(typeof(TEntity), path))
-            {
-                throw new JsonPatchParseException(String.Format("The path '{0}' is not valid.", path));
-            }
-
-            _operations.Add(new JsonPatchOperation
-            {
-                Operation = JsonPatchOperationType.add,
-                PropertyName = path,
-                Value = value
-            });
+            UpdateOperations(path, JsonPatchOperationType.add, value);
         }
 
         public void Replace(string path, object value)
         {
-            if (!PathHelper.IsPathValid(typeof(TEntity), path))
-            {
-                throw new JsonPatchParseException(String.Format("The path '{0}' is not valid.", path));
-            }
-
-            _operations.Add(new JsonPatchOperation
-            {
-                Operation = JsonPatchOperationType.replace,
-                PropertyName = path,
-                Value = value
-            });
+            UpdateOperations(path, JsonPatchOperationType.replace, value);
         }
 
         public void Remove(string path)
         {
-            if (!PathHelper.IsPathValid(typeof(TEntity), path))
-            {
-                throw new JsonPatchParseException(String.Format("The path '{0}' is not valid.", path));
-            }
-            
-
-            _operations.Add(new JsonPatchOperation
-            {
-                Operation = JsonPatchOperationType.remove,
-                PropertyName = path
-            });
+            UpdateOperations(path, JsonPatchOperationType.remove);
         }
 
         public void ApplyUpdatesTo(TEntity entity)
         {
+            if (entity == null)
+            {
+                throw new ArgumentNullException("entity");
+            }
+
             foreach (var operation in _operations)
             {
                 if (operation.Operation == JsonPatchOperationType.remove)
@@ -77,6 +53,21 @@ namespace JsonPatch
                     PathHelper.SetValueFromPath(typeof(TEntity), operation.PropertyName, entity, operation.Value, JsonPatchOperationType.add);
                 }
             }
+        }
+
+        private void UpdateOperations(string property, JsonPatchOperationType operation, object value = null)
+        {
+            if (!PathHelper.IsPathValid(typeof(TEntity), property))
+            {
+                throw new JsonPatchParseException(String.Format("The path '{0}' is not valid.", property));
+            }
+
+            _operations.Add(new JsonPatchOperation
+            {
+                Operation = operation,
+                PropertyName = property,
+                Value = value
+            });
         }
     }
 }


### PR DESCRIPTION
By making the path case insensitive there is a possibility that if a class has 2 properties with the same name that only differ by case name then an exception would be thrown as the LINQ operator `Single()` is used, e.g.
```
public class SimpleEntity
{
  public string Foo { get; set; }
  public string FOO { get; set; }
}
```
Personally I don't feel that this is an issue as I see this as a bad practice, the fact it means that API consumers don't need to worry about the case of properties outweighs the possibility of an issue IMO.

I also added a `.HasOperations` property to the Document because I found myself checking to see if the patch document had properties fairly frequently as it enabled me to return a 400 prior to any processing.