### PR TITLE
Generate Diff Helper

### DIFF
--- a/src/JsonPatch.Tests/DiffHelperTests.cs
+++ b/src/JsonPatch.Tests/DiffHelperTests.cs
@@ -18,7 +18,7 @@ namespace JsonPatch.Tests
             SimpleEntity originalDocument = new SimpleEntity() { Foo = "bar" };
             SimpleEntity modifiedDocument = new SimpleEntity() { Foo = "baz" };
 
-            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(typeof(SimpleEntity), originalDocument, modifiedDocument).ToList();
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(originalDocument, modifiedDocument).ToList();
 
             Assert.AreEqual(1, operations.Count);
             Assert.AreEqual(JsonPatchOperationType.replace, operations.First().Operation);
@@ -32,7 +32,7 @@ namespace JsonPatch.Tests
             SimpleEntity originalDocument = new SimpleEntity() { Foo = "bar" };
             SimpleEntity modifiedDocument = new SimpleEntity() { Foo = null };
 
-            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(typeof(SimpleEntity), originalDocument, modifiedDocument).ToList();
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(originalDocument, modifiedDocument).ToList();
 
             Assert.AreEqual(1, operations.Count);
             Assert.AreEqual(JsonPatchOperationType.remove, operations.First().Operation);
@@ -48,7 +48,7 @@ namespace JsonPatch.Tests
             NestedEntity modifiedDocument = new NestedEntity();
             modifiedDocument.Foo = new SimpleEntity() { Foo = "baz" };
 
-            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(typeof(NestedEntity), originalDocument, modifiedDocument).ToList();
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(originalDocument, modifiedDocument).ToList();
 
             Assert.AreEqual(1, operations.Count);
             Assert.AreEqual(JsonPatchOperationType.replace, operations.First().Operation);
@@ -64,7 +64,8 @@ namespace JsonPatch.Tests
             ArrayEntity modifiedDocument = new ArrayEntity();
             modifiedDocument.Foo = new string[] { "bar", "baz" };
 
-            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(typeof(ArrayEntity), originalDocument, modifiedDocument).ToList();
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(originalDocument, modifiedDocument).ToList();
+
             Assert.AreEqual(1, operations.Count);
             Assert.AreEqual(JsonPatchOperationType.add, operations.First().Operation);
             Assert.AreEqual("/Foo/1", operations.First().PropertyName);
@@ -79,10 +80,27 @@ namespace JsonPatch.Tests
             ArrayEntity modifiedDocument = new ArrayEntity();
             modifiedDocument.Foo = new string[] {  };
 
-            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(typeof(ArrayEntity), originalDocument, modifiedDocument).ToList();
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(originalDocument, modifiedDocument).ToList();
+
             Assert.AreEqual(1, operations.Count);
             Assert.AreEqual(JsonPatchOperationType.remove, operations.First().Operation);
             Assert.AreEqual("/Foo/0", operations.First().PropertyName);
+        }
+
+        [TestMethod]
+        public void GenerateDiff_ArrayEntityModify_ReturnsReplaceOperation()
+        {
+            ArrayEntity originalDocument = new ArrayEntity();
+            originalDocument.Foo = new string[] { "bar" };
+            ArrayEntity modifiedDocument = new ArrayEntity();
+            modifiedDocument.Foo = new string[] { "baz" };
+
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(originalDocument, modifiedDocument).ToList();
+
+            Assert.AreEqual(1, operations.Count);
+            Assert.AreEqual(JsonPatchOperationType.replace, operations.First().Operation);
+            Assert.AreEqual("/Foo/0", operations.First().PropertyName);
+            Assert.AreEqual("baz", operations.First().Value);
         }
     }
 }

--- a/src/JsonPatch.Tests/DiffHelperTests.cs
+++ b/src/JsonPatch.Tests/DiffHelperTests.cs
@@ -26,6 +26,19 @@ namespace JsonPatch.Tests
             Assert.AreEqual(modifiedDocument.Foo, operations.First().Value);
         }
 
+		[TestMethod]
+		public void GenerateDiff_SimpleEntitySetNullableToNull_ReturnsRemoveOperation()
+		{
+			SimpleEntity originalDocument = new SimpleEntity() { Bar = 1 };
+			SimpleEntity modifiedDocument = new SimpleEntity() { Bar = null };
+
+			List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(originalDocument, modifiedDocument).ToList();
+
+			Assert.AreEqual(1, operations.Count);
+			Assert.AreEqual(JsonPatchOperationType.remove, operations.First().Operation);
+			Assert.AreEqual("/Bar", operations.First().PropertyName);
+		}
+
         [TestMethod]
         public void GenerateDiff_SimpleEntityRemove_ReturnsRemoveOperation()
         {
@@ -149,5 +162,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual("/Foo/0", operations.First().PropertyName);
             Assert.AreEqual("baz", operations.First().Value);
         }
+
+
     }
 }

--- a/src/JsonPatch.Tests/DiffHelperTests.cs
+++ b/src/JsonPatch.Tests/DiffHelperTests.cs
@@ -26,18 +26,19 @@ namespace JsonPatch.Tests
             Assert.AreEqual(modifiedDocument.Foo, operations.First().Value);
         }
 
-		[TestMethod]
-		public void GenerateDiff_SimpleEntitySetNullableToNull_ReturnsRemoveOperation()
-		{
-			SimpleEntity originalDocument = new SimpleEntity() { Bar = 1 };
-			SimpleEntity modifiedDocument = new SimpleEntity() { Bar = null };
+        [TestMethod]
+        public void GenerateDiff_SimpleEntitySetNullableToNull_ReturnsRemoveOperation()
+        {
+            SimpleEntity originalDocument = new SimpleEntity() { Bar = 1 };
+            SimpleEntity modifiedDocument = new SimpleEntity() { Bar = null };
 
-			List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(originalDocument, modifiedDocument).ToList();
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(originalDocument, modifiedDocument).ToList();
 
-			Assert.AreEqual(1, operations.Count);
-			Assert.AreEqual(JsonPatchOperationType.remove, operations.First().Operation);
-			Assert.AreEqual("/Bar", operations.First().PropertyName);
-		}
+            Assert.AreEqual(1, operations.Count);
+            Assert.AreEqual(JsonPatchOperationType.remove, operations.First().Operation);
+            Assert.AreEqual("/Bar", operations.First().PropertyName);
+            Assert.IsNull(operations.First().Value);
+        }
 
         [TestMethod]
         public void GenerateDiff_SimpleEntityRemove_ReturnsRemoveOperation()
@@ -50,7 +51,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual(1, operations.Count);
             Assert.AreEqual(JsonPatchOperationType.remove, operations.First().Operation);
             Assert.AreEqual("/Foo", operations.First().PropertyName);
-            Assert.AreEqual(modifiedDocument.Foo, operations.First().Value);
+            Assert.IsNull(operations.First().Value);
         }
 
         [TestMethod]
@@ -98,6 +99,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual(1, operations.Count);
             Assert.AreEqual(JsonPatchOperationType.remove, operations.First().Operation);
             Assert.AreEqual("/Foo/0", operations.First().PropertyName);
+            Assert.IsNull(operations.First().Value);
         }
 
         [TestMethod]
@@ -145,6 +147,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual(1, operations.Count);
             Assert.AreEqual(JsonPatchOperationType.remove, operations.First().Operation);
             Assert.AreEqual("/Foo/0", operations.First().PropertyName);
+            Assert.IsNull(operations.First().Value);
         }
 
         [TestMethod]
@@ -163,6 +166,34 @@ namespace JsonPatch.Tests
             Assert.AreEqual("baz", operations.First().Value);
         }
 
+        [TestMethod]
+        public void GenerateDiff_ComplexEntitySetNull_ReturnsRemoveOperation()
+        {
+            ComplexEntity originalDocument = new ComplexEntity();
+            originalDocument.Foo = new ArrayEntity();
+            ComplexEntity modifiedDocument = new ComplexEntity();
 
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(originalDocument, modifiedDocument).ToList();
+
+            Assert.AreEqual(1, operations.Count);
+            Assert.AreEqual(JsonPatchOperationType.remove, operations.First().Operation);
+            Assert.AreEqual("/Foo", operations.First().PropertyName);
+            Assert.IsNull(operations.First().Value);
+        }
+
+        [TestMethod]
+        public void GenerateDiff_ComplexEntitySetProperty_ReturnsAddOperation()
+        {
+            ComplexEntity originalDocument = new ComplexEntity();
+            ComplexEntity modifiedDocument = new ComplexEntity();
+            modifiedDocument.Foo = new ArrayEntity();
+
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(originalDocument, modifiedDocument).ToList();
+
+            Assert.AreEqual(1, operations.Count);
+            Assert.AreEqual(JsonPatchOperationType.add, operations.First().Operation);
+            Assert.AreEqual("/Foo", operations.First().PropertyName);
+            Assert.AreEqual(modifiedDocument.Foo, operations.First().Value);
+        }
     }
 }

--- a/src/JsonPatch.Tests/DiffHelperTests.cs
+++ b/src/JsonPatch.Tests/DiffHelperTests.cs
@@ -39,5 +39,50 @@ namespace JsonPatch.Tests
             Assert.AreEqual("/Foo", operations.First().PropertyName);
             Assert.AreEqual(modifiedDocument.Foo, operations.First().Value);
         }
+
+        [TestMethod]
+        public void GenerateDiff_NestedEntityReplace_ReturnsReplaceOperation()
+        {
+            NestedEntity originalDocument = new NestedEntity();
+            originalDocument.Foo = new SimpleEntity() { Foo = "bar" };
+            NestedEntity modifiedDocument = new NestedEntity();
+            modifiedDocument.Foo = new SimpleEntity() { Foo = "baz" };
+
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(typeof(NestedEntity), originalDocument, modifiedDocument).ToList();
+
+            Assert.AreEqual(1, operations.Count);
+            Assert.AreEqual(JsonPatchOperationType.replace, operations.First().Operation);
+            Assert.AreEqual("/Foo/Foo", operations.First().PropertyName);
+            Assert.AreEqual(modifiedDocument.Foo.Foo, operations.First().Value);
+        }
+
+        [TestMethod]
+        public void GenerateDiff_ArrayEntityAdd_ReturnsAddOperation()
+        {
+            ArrayEntity originalDocument = new ArrayEntity();
+            originalDocument.Foo = new string[] { "bar" };
+            ArrayEntity modifiedDocument = new ArrayEntity();
+            modifiedDocument.Foo = new string[] { "bar", "baz" };
+
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(typeof(ArrayEntity), originalDocument, modifiedDocument).ToList();
+            Assert.AreEqual(1, operations.Count);
+            Assert.AreEqual(JsonPatchOperationType.add, operations.First().Operation);
+            Assert.AreEqual("/Foo/1", operations.First().PropertyName);
+            Assert.AreEqual("baz", operations.First().Value);
+        }
+
+        [TestMethod]
+        public void GenerateDiff_ArrayEntityRemove_ReturnsRemoveOperation()
+        {
+            ArrayEntity originalDocument = new ArrayEntity();
+            originalDocument.Foo = new string[] { "bar" };
+            ArrayEntity modifiedDocument = new ArrayEntity();
+            modifiedDocument.Foo = new string[] {  };
+
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(typeof(ArrayEntity), originalDocument, modifiedDocument).ToList();
+            Assert.AreEqual(1, operations.Count);
+            Assert.AreEqual(JsonPatchOperationType.remove, operations.First().Operation);
+            Assert.AreEqual("/Foo/0", operations.First().PropertyName);
+        }
     }
 }

--- a/src/JsonPatch.Tests/DiffHelperTests.cs
+++ b/src/JsonPatch.Tests/DiffHelperTests.cs
@@ -102,5 +102,52 @@ namespace JsonPatch.Tests
             Assert.AreEqual("/Foo/0", operations.First().PropertyName);
             Assert.AreEqual("baz", operations.First().Value);
         }
+
+        [TestMethod]
+        public void GenerateDiff_ListEntityAdd_ReturnsAddOperation()
+        {
+            ListEntity originalDocument = new ListEntity();
+            originalDocument.Foo = new List<string>() { "bar" };
+            ListEntity modifiedDocument = new ListEntity();
+            modifiedDocument.Foo = new List<string>() { "bar", "baz" };
+
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(originalDocument, modifiedDocument).ToList();
+
+            Assert.AreEqual(1, operations.Count);
+            Assert.AreEqual(JsonPatchOperationType.add, operations.First().Operation);
+            Assert.AreEqual("/Foo/1", operations.First().PropertyName);
+            Assert.AreEqual("baz", operations.First().Value);
+        }
+
+        [TestMethod]
+        public void GenerateDiff_ListEntityRemove_ReturnsRemoveOperation()
+        {
+            ListEntity originalDocument = new ListEntity();
+            originalDocument.Foo = new List<string>() { "bar" };
+            ListEntity modifiedDocument = new ListEntity();
+            modifiedDocument.Foo = new List<string>();
+
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(originalDocument, modifiedDocument).ToList();
+
+            Assert.AreEqual(1, operations.Count);
+            Assert.AreEqual(JsonPatchOperationType.remove, operations.First().Operation);
+            Assert.AreEqual("/Foo/0", operations.First().PropertyName);
+        }
+
+        [TestMethod]
+        public void GenerateDiff_ListEntityModify_ReturnsReplaceOperation()
+        {
+            ListEntity originalDocument = new ListEntity();
+            originalDocument.Foo = new List<string>() { "bar" };
+            ListEntity modifiedDocument = new ListEntity();
+            modifiedDocument.Foo = new List<string>() { "baz" };
+
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(originalDocument, modifiedDocument).ToList();
+
+            Assert.AreEqual(1, operations.Count);
+            Assert.AreEqual(JsonPatchOperationType.replace, operations.First().Operation);
+            Assert.AreEqual("/Foo/0", operations.First().PropertyName);
+            Assert.AreEqual("baz", operations.First().Value);
+        }
     }
 }

--- a/src/JsonPatch.Tests/DiffHelperTests.cs
+++ b/src/JsonPatch.Tests/DiffHelperTests.cs
@@ -1,0 +1,43 @@
+﻿using JsonPatch.Helpers;
+using JsonPatch.Tests.Entitys;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JsonPatch.Tests
+{
+    [TestClass]
+    public class DiffHelperTests
+    {
+        [TestMethod]
+        public void GenerateDiff_SimpleEntityReplace_ReturnsReplaceOperation()
+        {
+            SimpleEntity originalDocument = new SimpleEntity() { Foo = "bar" };
+            SimpleEntity modifiedDocument = new SimpleEntity() { Foo = "baz" };
+
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(typeof(SimpleEntity), originalDocument, modifiedDocument).ToList();
+
+            Assert.AreEqual(1, operations.Count);
+            Assert.AreEqual(JsonPatchOperationType.replace, operations.First().Operation);
+            Assert.AreEqual("/Foo", operations.First().PropertyName);
+            Assert.AreEqual(modifiedDocument.Foo, operations.First().Value);
+        }
+
+        [TestMethod]
+        public void GenerateDiff_SimpleEntityRemove_ReturnsRemoveOperation()
+        {
+            SimpleEntity originalDocument = new SimpleEntity() { Foo = "bar" };
+            SimpleEntity modifiedDocument = new SimpleEntity() { Foo = null };
+
+            List<JsonPatchOperation> operations = DiffHelper.GenerateDiff(typeof(SimpleEntity), originalDocument, modifiedDocument).ToList();
+
+            Assert.AreEqual(1, operations.Count);
+            Assert.AreEqual(JsonPatchOperationType.remove, operations.First().Operation);
+            Assert.AreEqual("/Foo", operations.First().PropertyName);
+            Assert.AreEqual(modifiedDocument.Foo, operations.First().Value);
+        }
+    }
+}

--- a/src/JsonPatch.Tests/Entitys/NestedEntity.cs
+++ b/src/JsonPatch.Tests/Entitys/NestedEntity.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JsonPatch.Tests.Entitys
+{
+    public class NestedEntity
+    {
+        public SimpleEntity Foo { get; set; }
+    }
+}

--- a/src/JsonPatch.Tests/Entitys/SimpleEntity.cs
+++ b/src/JsonPatch.Tests/Entitys/SimpleEntity.cs
@@ -10,5 +10,6 @@ namespace JsonPatch.Tests.Entitys
     {
         public string Foo { get; set; }
         public string Baz { get; set; }
+		public int? Bar { get; set; }
     }
 }

--- a/src/JsonPatch.Tests/JsonPatch.Tests.csproj
+++ b/src/JsonPatch.Tests/JsonPatch.Tests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Entitys\ArrayEntity.cs" />
     <Compile Include="Entitys\ComplexEntity.cs" />
     <Compile Include="Entitys\ListEntity.cs" />
+    <Compile Include="Entitys\NestedEntity.cs" />
     <Compile Include="Entitys\SimpleEntity.cs" />
     <Compile Include="JsonPatchDocumentTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/JsonPatch.Tests/JsonPatch.Tests.csproj
+++ b/src/JsonPatch.Tests/JsonPatch.Tests.csproj
@@ -56,6 +56,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="DiffHelperTests.cs" />
     <Compile Include="Entitys\ArrayEntity.cs" />
     <Compile Include="Entitys\ComplexEntity.cs" />
     <Compile Include="Entitys\ListEntity.cs" />

--- a/src/JsonPatch.Tests/PathHelperTests.cs
+++ b/src/JsonPatch.Tests/PathHelperTests.cs
@@ -141,15 +141,15 @@ namespace JsonPatch.Tests
             Assert.IsTrue(isValid);
         }
 
-		[TestMethod]
-		public void IsPathValid_ChildPathOnList_ReturnsTrue()
-		{
-			//act
-			var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/Qux/1/Foo");
+        [TestMethod]
+        public void IsPathValid_ChildPathOnList_ReturnsTrue()
+        {
+            //act
+            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/Qux/1/Foo");
 
-			//assert
-			Assert.IsTrue(isValid);
-		}
+            //assert
+            Assert.IsTrue(isValid);
+        }
 
         [TestMethod]
         public void IsPathValid_PathOnChildArray_ReturnsTrue()
@@ -270,22 +270,22 @@ namespace JsonPatch.Tests
             Assert.AreEqual(2, entity.Foo.Length);
         }
 
-		[TestMethod]
-		public void SetValueFromPath_ReplaceListValue_UpdatesValue()
-		{
-			//Arrange
-			var entity = new ListEntity
-			{
-				Foo = new List<string> { "Element One", "Element Two" }
-			};
+        [TestMethod]
+        public void SetValueFromPath_ReplaceListValue_UpdatesValue()
+        {
+            //Arrange
+            var entity = new ListEntity
+            {
+                Foo = new List<string> { "Element One", "Element Two" }
+            };
 
-			//act
-			PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/1", entity, "Element Two Updated", JsonPatchOperationType.replace);
+            //act
+            PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/1", entity, "Element Two Updated", JsonPatchOperationType.replace);
 
-			//Assert
-			Assert.AreEqual("Element Two Updated", entity.Foo[1]);
-			Assert.AreEqual(2, entity.Foo.Count);
-		}
+            //Assert
+            Assert.AreEqual("Element Two Updated", entity.Foo[1]);
+            Assert.AreEqual(2, entity.Foo.Count);
+        }
 
         [TestMethod, ExpectedException(typeof(JsonPatchException))]
         public void SetValueFromPath_ReplaceIndexOutOfBounds_ThrowsJsonPatchException()
@@ -318,23 +318,23 @@ namespace JsonPatch.Tests
             Assert.AreEqual(3, entity.Foo.Length);
         }
 
-		[TestMethod]
-		public void SetValueFromPath_AddListValue_AddsValue()
-		{
-			//Arrange
-			var entity = new ListEntity
-			{
-				Foo = new List<string> { "Element One", "Element Two" }
-			};
+        [TestMethod]
+        public void SetValueFromPath_AddListValue_AddsValue()
+        {
+            //Arrange
+            var entity = new ListEntity
+            {
+                Foo = new List<string> { "Element One", "Element Two" }
+            };
 
-			//act
-			PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/1", entity, "Element Two Updated", JsonPatchOperationType.add);
+            //act
+            PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/1", entity, "Element Two Updated", JsonPatchOperationType.add);
 
-			//Assert
-			Assert.AreEqual("Element Two Updated", entity.Foo[1]);
-			Assert.AreEqual("Element Two", entity.Foo[2]);
-			Assert.AreEqual(3, entity.Foo.Count);
-		}
+            //Assert
+            Assert.AreEqual("Element Two Updated", entity.Foo[1]);
+            Assert.AreEqual("Element Two", entity.Foo[2]);
+            Assert.AreEqual(3, entity.Foo.Count);
+        }
 
         [TestMethod]
         public void SetValueFromPath_AddArrayValueAtEnd_AddsValue()
@@ -354,23 +354,23 @@ namespace JsonPatch.Tests
             Assert.AreEqual(3, entity.Foo.Length);
         }
 
-		[TestMethod]
-		public void SetValueFromPath_AddListValueAtEnd_AddsValue()
-		{
-			//Arrange
-			var entity = new ListEntity
-			{
-				Foo = new List<string> { "Element One", "Element Two" }
-			};
+        [TestMethod]
+        public void SetValueFromPath_AddListValueAtEnd_AddsValue()
+        {
+            //Arrange
+            var entity = new ListEntity
+            {
+                Foo = new List<string> { "Element One", "Element Two" }
+            };
 
-			//act
-			PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/2", entity, "Element Two Updated", JsonPatchOperationType.add);
+            //act
+            PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/2", entity, "Element Two Updated", JsonPatchOperationType.add);
 
-			//Assert
-			Assert.AreEqual("Element Two Updated", entity.Foo[2]);
-			Assert.AreEqual("Element Two", entity.Foo[1]);
-			Assert.AreEqual(3, entity.Foo.Count);
-		}
+            //Assert
+            Assert.AreEqual("Element Two Updated", entity.Foo[2]);
+            Assert.AreEqual("Element Two", entity.Foo[1]);
+            Assert.AreEqual(3, entity.Foo.Count);
+        }
 
         [TestMethod, ExpectedException(typeof(JsonPatchException))]
         public void SetValueFromPath_AddIndexOutOfBounds_ThrowsJsonPatchException()
@@ -419,39 +419,39 @@ namespace JsonPatch.Tests
             Assert.AreEqual(1, entity.Foo.Length);
         }
 
-		[TestMethod]
-		public void SetValueFromPath_RemoveListValueFromStart_RemovesValue()
-		{
-			//Arrange
-			var entity = new ListEntity
-			{
-				Foo = new List<string> { "Element One", "Element Two" }
-			};
+        [TestMethod]
+        public void SetValueFromPath_RemoveListValueFromStart_RemovesValue()
+        {
+            //Arrange
+            var entity = new ListEntity
+            {
+                Foo = new List<string> { "Element One", "Element Two" }
+            };
 
-			//act
-			PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/0", entity, null, JsonPatchOperationType.remove);
+            //act
+            PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/0", entity, null, JsonPatchOperationType.remove);
 
-			//Assert
-			Assert.AreEqual("Element Two", entity.Foo[0]);
-			Assert.AreEqual(1, entity.Foo.Count);
-		}
+            //Assert
+            Assert.AreEqual("Element Two", entity.Foo[0]);
+            Assert.AreEqual(1, entity.Foo.Count);
+        }
 
-		[TestMethod]
-		public void SetValueFromPath_RemoveListValueFromEnd_RemovesValue()
-		{
-			//Arrange
-			var entity = new ListEntity
-			{
-				Foo = new List<string> { "Element One", "Element Two" }
-			};
+        [TestMethod]
+        public void SetValueFromPath_RemoveListValueFromEnd_RemovesValue()
+        {
+            //Arrange
+            var entity = new ListEntity
+            {
+                Foo = new List<string> { "Element One", "Element Two" }
+            };
 
-			//act
-			PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/1", entity, null, JsonPatchOperationType.remove);
+            //act
+            PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/1", entity, null, JsonPatchOperationType.remove);
 
-			//Assert
-			Assert.AreEqual("Element One", entity.Foo[0]);
-			Assert.AreEqual(1, entity.Foo.Count);
-		}
+            //Assert
+            Assert.AreEqual("Element One", entity.Foo[0]);
+            Assert.AreEqual(1, entity.Foo.Count);
+        }
 
 
         [TestMethod, ExpectedException(typeof(JsonPatchException))]
@@ -518,21 +518,21 @@ namespace JsonPatch.Tests
             Assert.AreEqual("New Value", entity.Baz[0].Foo);
         }
 
-		[TestMethod]
-		public void SetValueFromPath_NestedAddToEmptyList_CreatesListAndAddsValue()
-		{
-			//arrange
-			var entity = new ComplexEntity
-			{
-				Qux = new List<SimpleEntity> { new SimpleEntity { Foo = "Foo" } }
-			};
+        [TestMethod]
+        public void SetValueFromPath_NestedAddToEmptyList_CreatesListAndAddsValue()
+        {
+            //arrange
+            var entity = new ComplexEntity
+            {
+                Qux = new List<SimpleEntity> { new SimpleEntity { Foo = "Foo" } }
+            };
 
-			//act
-			PathHelper.SetValueFromPath(typeof(ComplexEntity), "/Qux/0/Foo", entity, "New Value", JsonPatchOperationType.replace);
+            //act
+            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/Qux/0/Foo", entity, "New Value", JsonPatchOperationType.replace);
 
-			//assert
-			Assert.AreEqual("New Value", entity.Qux[0].Foo);
-		}
+            //assert
+            Assert.AreEqual("New Value", entity.Qux[0].Foo);
+        }
         #endregion
     }
 }

--- a/src/JsonPatch/Helpers/DiffHelper.cs
+++ b/src/JsonPatch/Helpers/DiffHelper.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JsonPatch.Helpers
+{
+    public static class DiffHelper
+    {
+        public static IEnumerable<JsonPatchOperation> GenerateDiff(Type entity, object originalDocument, object modifiedDocument, string path = "/")
+        {
+            if (originalDocument.GetType() != entity)
+                throw new ArgumentException(string.Format("Original Document is type of {0} but requested type is {1}", originalDocument.GetType().ToString(), entity.ToString()));
+
+            if (modifiedDocument.GetType() != entity)
+                throw new ArgumentException(string.Format("Modified Document is type of {0} but requested type is {1}", modifiedDocument.GetType().ToString(), entity.ToString()));
+
+            var propertyList = entity.GetProperties();
+            foreach (var property in propertyList)
+            {
+                var originalValue = property.GetValue(originalDocument);
+                var modifiedValue = property.GetValue(modifiedDocument);
+
+                if (originalValue != modifiedValue)
+                {
+                    yield return new JsonPatchOperation()
+                    {
+                        Operation = modifiedValue == null ? JsonPatchOperationType.remove : JsonPatchOperationType.replace,
+                        PropertyName = path + property.Name,
+                        Value = property.GetValue(modifiedDocument)
+                    };
+                }
+            }
+
+            yield break;
+        }
+    }
+}

--- a/src/JsonPatch/Helpers/PathHelper.cs
+++ b/src/JsonPatch/Helpers/PathHelper.cs
@@ -57,8 +57,8 @@ namespace JsonPatch.Helpers
 
             if (currentPathComponent.IsPositiveInteger())
             {
-				//Cast it once to an iList to save CPU. 
-				var listEntity = (IList)entity;
+                //Cast it once to an iList to save CPU. 
+                var listEntity = (IList)entity;
                 var numberOfElements = (listEntity).Count;
                 var accessIndex = currentPathComponent.ToInt32();
 
@@ -79,59 +79,59 @@ namespace JsonPatch.Helpers
                 {
                     if (operationType == JsonPatchOperationType.add)
                     {
-						//If this isn't an array, we can just insert it and return. 
-						if (listEntity is Array == false)
-						{
-							listEntity.Insert(accessIndex, JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), entityType.GetGenericArguments().First()));
-							return listEntity;
-						}
+                        //If this isn't an array, we can just insert it and return. 
+                        if (listEntity is Array == false)
+                        {
+                            listEntity.Insert(accessIndex, JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), entityType.GetGenericArguments().First()));
+                            return listEntity;
+                        }
 
                         var oldArray = listEntity;
-						IList newArray = (IList)Activator.CreateInstance(entityType, new object[] { (oldArray).Count + 1 });
+                        IList newArray = (IList)Activator.CreateInstance(entityType, new object[] { (oldArray).Count + 1 });
 
                         for (int i = 0; i < newArray.Count; i++)
                         {
-							if (i < accessIndex)
-								newArray[i] = oldArray[i];
+                            if (i < accessIndex)
+                                newArray[i] = oldArray[i];
                             if (i == accessIndex)
-								newArray[i] = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), entityType.GetElementType());
-							if (i > accessIndex)
-								newArray[i] = oldArray[i - 1];
+                                newArray[i] = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), entityType.GetElementType());
+                            if (i > accessIndex)
+                                newArray[i] = oldArray[i - 1];
                         }
 
                         return newArray;
                     }
                     else if (operationType == JsonPatchOperationType.remove)
                     {
-						//If this isn't an array, we can just remove at and return. 
-						if (listEntity is Array == false)
-						{
-							listEntity.RemoveAt(accessIndex);
-							return listEntity;
-						}
+                        //If this isn't an array, we can just remove at and return. 
+                        if (listEntity is Array == false)
+                        {
+                            listEntity.RemoveAt(accessIndex);
+                            return listEntity;
+                        }
 
-						var oldArray = listEntity;
-						var newArray = (IList)Activator.CreateInstance(entityType, new object[] { (oldArray).Count - 1 });
+                        var oldArray = listEntity;
+                        var newArray = (IList)Activator.CreateInstance(entityType, new object[] { (oldArray).Count - 1 });
 
-						for (int i = 0; i < oldArray.Count; i++)
-						{
-							if (i < accessIndex)
-								newArray[i] = oldArray[i];
-							if (i > accessIndex)
-								newArray[i - 1] = oldArray[i];
-						}
+                        for (int i = 0; i < oldArray.Count; i++)
+                        {
+                            if (i < accessIndex)
+                                newArray[i] = oldArray[i];
+                            if (i > accessIndex)
+                                newArray[i - 1] = oldArray[i];
+                        }
 
-						return newArray;
+                        return newArray;
                     }
                     else
                     {
-						listEntity[accessIndex] = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), entityType.GetElementType() ?? entityType.GetGenericArguments().First());
+                        listEntity[accessIndex] = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), entityType.GetElementType() ?? entityType.GetGenericArguments().First());
                         return entity;
                     }
                 }
 
-				var updatedEntity = SetValueFromPath(entityType.GetElementType() ?? entityType.GetGenericArguments().First(), String.Join("/", pathComponents.Skip(1)), listEntity[accessIndex], value, operationType);
-				listEntity[accessIndex] = updatedEntity;
+                var updatedEntity = SetValueFromPath(entityType.GetElementType() ?? entityType.GetGenericArguments().First(), String.Join("/", pathComponents.Skip(1)), listEntity[accessIndex], value, operationType);
+                listEntity[accessIndex] = updatedEntity;
 
             }else if (entityType.GetProperties().Any(p => p.Name == pathComponents[0]))
             {

--- a/src/JsonPatch/JsonPatch.csproj
+++ b/src/JsonPatch/JsonPatch.csproj
@@ -50,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Constants.cs" />
+    <Compile Include="Helpers\DiffHelper.cs" />
     <Compile Include="JsonPatchParseException.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Formatting\JsonPatchFormatter.cs" />


### PR DESCRIPTION
Created a "Diff Helper" to compare two C# objects and output an IEnumerable of JsonPatchOperations to be performed. I suppose this may be outside the realms of what JsonPatch is supposed to be used for, but the patching operations became useful to me between C# code so it's there. The original idea was that you can then output via JSON the JsonPatchOperations and send them to another system. 

Slightly messy commit as I also fixed a previous pull request of mine where I had used Tabs instead of the project default of Spaces. 