### PR TITLE
 Fix for issue #10 - Allow CaseInsensitive path matching

### DIFF
--- a/src/JsonPatch.Tests/CaseInsensitivePathHelperTests.cs
+++ b/src/JsonPatch.Tests/CaseInsensitivePathHelperTests.cs
@@ -10,14 +10,14 @@ using JsonPatch.Paths.Resolvers;
 namespace JsonPatch.Tests
 {
     [TestClass]
-    public class PathHelperTests
+    public class CaseInsensitivePathHelperTests
     {
-        private ExactCasePropertyPathResolver _resolver;
+        private CaseInsensitivePropertyPathResolver _resolver;
 
         [TestInitialize]
         public void SetResolver()
         {
-            _resolver = new ExactCasePropertyPathResolver();
+            _resolver = new CaseInsensitivePropertyPathResolver();
             var settings = new JsonPatchSettings
             {
                 PathResolver = _resolver
@@ -32,11 +32,11 @@ namespace JsonPatch.Tests
         public void ParsePath_SimpleProperty_ParsesSuccessfully()
         {
             //act
-            var pathComponents = PathHelper.ParsePath("Bar", typeof(SimpleEntity));
+            var pathComponents = PathHelper.ParsePath("bar", typeof(SimpleEntity));
 
             //assert
             Assert.AreEqual(1, pathComponents.Length);
-            Assert.AreEqual("Bar", pathComponents[0].Name);
+            Assert.AreEqual("bar", pathComponents[0].Name);
             Assert.IsInstanceOfType(pathComponents[0], typeof(PropertyPathComponent));
             Assert.AreEqual(typeof(int), pathComponents[0].ComponentType);
             Assert.IsFalse(pathComponents[0].IsCollection);
@@ -46,29 +46,29 @@ namespace JsonPatch.Tests
         public void ParsePath_LeadingSlash_SlashIgnored()
         {
             //act
-            var pathComponents = PathHelper.ParsePath("/Foo", typeof(SimpleEntity));
+            var pathComponents = PathHelper.ParsePath("/foo", typeof(SimpleEntity));
 
             //assert
             Assert.AreEqual(1, pathComponents.Length);
-            Assert.AreEqual("Foo", pathComponents[0].Name);
+            Assert.AreEqual("foo", pathComponents[0].Name);
         }
 
         [TestMethod]
         public void ParsePath_LeadingAndTrailingSlashes_SlashesIgnored()
         {
             //act
-            var pathComponents = PathHelper.ParsePath("/Foo/", typeof(SimpleEntity));
+            var pathComponents = PathHelper.ParsePath("/foo/", typeof(SimpleEntity));
 
             //assert
             Assert.AreEqual(1, pathComponents.Length);
-            Assert.AreEqual("Foo", pathComponents[0].Name);
+            Assert.AreEqual("foo", pathComponents[0].Name);
         }
 
         [TestMethod, ExpectedException(typeof(JsonPatchParseException))]
         public void ParsePath_InvalidProperty_ThrowsException()
         {
             //act
-            PathHelper.ParsePath("Quux", typeof(SimpleEntity));
+            PathHelper.ParsePath("quux", typeof(SimpleEntity));
         }
 
         [TestMethod, ExpectedException(typeof(JsonPatchParseException))]
@@ -82,11 +82,11 @@ namespace JsonPatch.Tests
         public void ParsePath_CollectionIndex_ParsesSuccessfully()
         {
             //act
-            var pathComponents = PathHelper.ParsePath("/Foo/5", typeof(ListEntity));
+            var pathComponents = PathHelper.ParsePath("/foo/5", typeof(ListEntity));
 
             //assert
             Assert.AreEqual(2, pathComponents.Length);
-            Assert.AreEqual("Foo", pathComponents[0].Name);
+            Assert.AreEqual("foo", pathComponents[0].Name);
             Assert.IsTrue(pathComponents[0].IsCollection);
             Assert.AreEqual("5", pathComponents[1].Name);
             Assert.IsInstanceOfType(pathComponents[1], typeof(CollectionIndexPathComponent));
@@ -98,7 +98,7 @@ namespace JsonPatch.Tests
         public void ParsePath_CollectionIndexAfterNonCollectionProperty_ParsesSuccessfully()
         {
             //act
-            PathHelper.ParsePath("/Bar/5", typeof(SimpleEntity));
+            PathHelper.ParsePath("/bar/5", typeof(SimpleEntity));
         }
 
         #endregion
@@ -131,7 +131,7 @@ namespace JsonPatch.Tests
         public void IsPathValid_PathBeginningWithANumber_ReturnsFalse()
         {
             //act
-            var isValid = PathHelper.IsPathValid(typeof(SimpleEntity), "/8/Foo");
+            var isValid = PathHelper.IsPathValid(typeof(SimpleEntity), "/8/foo");
 
             //assert
             Assert.IsTrue(isValid == false);
@@ -155,7 +155,7 @@ namespace JsonPatch.Tests
         public void IsPathValid_SimpleMissingPath_ReturnsFalse()
         {
             //act
-            var isValid = PathHelper.IsPathValid(typeof(SimpleEntity), "/MissingFoo");
+            var isValid = PathHelper.IsPathValid(typeof(SimpleEntity), "/missingFoo");
 
             //assert
             Assert.IsTrue(isValid == false);
@@ -165,7 +165,7 @@ namespace JsonPatch.Tests
         public void IsPathValid_NonIndexOnArray_ReturnsFalse()
         {
             //act
-            var isValid = PathHelper.IsPathValid(typeof(ArrayEntity), "/Foo/NotAnIndex");
+            var isValid = PathHelper.IsPathValid(typeof(ArrayEntity), "/foo/NotAnIndex");
 
             //assert
             Assert.IsTrue(isValid == false);
@@ -175,7 +175,7 @@ namespace JsonPatch.Tests
         public void IsPathValid_MissingPathOnChildEntity_ReturnsFalse()
         {
             //act
-            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/Bax/1/MissingFoo");
+            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/bax/1/MissingFoo");
 
             //assert
             Assert.IsTrue(isValid == false);
@@ -185,7 +185,7 @@ namespace JsonPatch.Tests
         public void IsPathValid_ChildIndexerOnNonArray_ReturnsFalse()
         {
             //act
-            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/Baz/1/1");
+            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/baz/1/1");
 
             //assert
             Assert.IsTrue(isValid == false);
@@ -199,7 +199,7 @@ namespace JsonPatch.Tests
         public void IsPathValid_SimplePath_ReturnsTrue()
         {
             //act
-            var isValid = PathHelper.IsPathValid(typeof(SimpleEntity), "/Foo");
+            var isValid = PathHelper.IsPathValid(typeof(SimpleEntity), "/foo");
 
             //assert
             Assert.IsTrue(isValid);
@@ -209,7 +209,7 @@ namespace JsonPatch.Tests
         public void IsPathValid_ArrayPath_ReturnsTrue()
         {
             //act
-            var isValid = PathHelper.IsPathValid(typeof(ArrayEntity), "/Foo/3");
+            var isValid = PathHelper.IsPathValid(typeof(ArrayEntity), "/foo/3");
 
             //assert
             Assert.IsTrue(isValid);
@@ -219,7 +219,7 @@ namespace JsonPatch.Tests
         public void IsPathValid_PathOnArrayEntity_ReturnsTrue()
         {
             //act
-            var isValid = PathHelper.IsPathValid(typeof(ArrayEntity), "/Foo/3");
+            var isValid = PathHelper.IsPathValid(typeof(ArrayEntity), "/foo/3");
 
             //assert
             Assert.IsTrue(isValid);
@@ -229,7 +229,7 @@ namespace JsonPatch.Tests
         public void IsPathValid_ChildPathOnArray_ReturnsTrue()
         {
             //act
-            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/Baz/1/Foo");
+            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/baz/1/foo");
 
             //assert
             Assert.IsTrue(isValid);
@@ -239,7 +239,7 @@ namespace JsonPatch.Tests
         public void IsPathValid_ChildPathOnList_ReturnsTrue()
         {
             //act
-            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/Qux/1/Foo");
+            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/quX/1/foo");
 
             //assert
             Assert.IsTrue(isValid);
@@ -249,7 +249,7 @@ namespace JsonPatch.Tests
         public void IsPathValid_PathOnChildArray_ReturnsTrue()
         {
             //act
-            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/Foo/Foo/1");
+            var isValid = PathHelper.IsPathValid(typeof(ComplexEntity), "/foo/foo/1");
 
             //assert
             Assert.IsTrue(isValid);
@@ -273,7 +273,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            var value = PathHelper.GetValueFromPath(typeof(SimpleEntity), "/Foo", entity);
+            var value = PathHelper.GetValueFromPath(typeof(SimpleEntity), "/foo", entity);
 
             //assert
             Assert.AreEqual("I am foo", value);
@@ -283,7 +283,7 @@ namespace JsonPatch.Tests
         public void GetValueFromPath_NullRoot_ThrowsException()
         {
             //act
-            PathHelper.GetValueFromPath(typeof(SimpleEntity), "/Foo", null);
+            PathHelper.GetValueFromPath(typeof(SimpleEntity), "/foo", null);
         }
 
         [TestMethod, ExpectedException(typeof(JsonPatchParseException))]
@@ -296,7 +296,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.GetValueFromPath(typeof(SimpleEntity), "/FooMissing", entity);
+            PathHelper.GetValueFromPath(typeof(SimpleEntity), "/Foomissing", entity);
         }
 
         #endregion
@@ -313,7 +313,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            var value = PathHelper.GetValueFromPath(typeof(ArrayEntity), "/Foo/1", entity);
+            var value = PathHelper.GetValueFromPath(typeof(ArrayEntity), "/foo/1", entity);
 
             //Assert
             Assert.AreEqual("Element Two", value);
@@ -329,7 +329,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.GetValueFromPath(typeof(ArrayEntity), "/Foo/5", entity);
+            PathHelper.GetValueFromPath(typeof(ArrayEntity), "/foo/5", entity);
         }
 
         #endregion
@@ -349,7 +349,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            var value = PathHelper.GetValueFromPath(typeof(ComplexEntity), "/Bar/Foo", entity);
+            var value = PathHelper.GetValueFromPath(typeof(ComplexEntity), "/bar/foo", entity);
 
             //assert
             Assert.AreEqual("I am foo", value);
@@ -369,7 +369,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            var value = PathHelper.GetValueFromPath(typeof(ComplexEntity), "/Norf/1/Foo/2", entity);
+            var value = PathHelper.GetValueFromPath(typeof(ComplexEntity), "/norf/1/foo/2", entity);
 
             //assert
             Assert.AreEqual("B3", value);
@@ -382,7 +382,7 @@ namespace JsonPatch.Tests
             var entity = new ComplexEntity { };
 
             //act
-            PathHelper.GetValueFromPath(typeof(ComplexEntity), "/Bar/Foo", entity);
+            PathHelper.GetValueFromPath(typeof(ComplexEntity), "/bar/foo", entity);
         }
 
         [TestMethod, ExpectedException(typeof(JsonPatchException))]
@@ -399,7 +399,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.GetValueFromPath(typeof(ComplexEntity), "/Qux/5/Foo", entity);
+            PathHelper.GetValueFromPath(typeof(ComplexEntity), "/qux/5/foo", entity);
         }
 
         [TestMethod, ExpectedException(typeof(JsonPatchException))]
@@ -412,7 +412,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.GetValueFromPath(typeof(ComplexEntity), "/Norf/0/Foo/0", entity);
+            PathHelper.GetValueFromPath(typeof(ComplexEntity), "/norf/0/foo/0", entity);
         }
 
         #endregion
@@ -437,7 +437,7 @@ namespace JsonPatch.Tests
             var entity = new SimpleEntity { };
 
             //act
-            PathHelper.SetValueFromPath(typeof(SimpleEntity), "/Foo", entity, "New Value", JsonPatchOperationType.add);
+            PathHelper.SetValueFromPath(typeof(SimpleEntity), "/foo", entity, "New Value", JsonPatchOperationType.add);
 
             //assert
             Assert.AreEqual("New Value", entity.Foo);
@@ -450,7 +450,7 @@ namespace JsonPatch.Tests
             var entity = new SimpleEntity { Foo = "Existing Value" };
 
             //act
-            PathHelper.SetValueFromPath(typeof(SimpleEntity), "/Foo", entity, "New Value", JsonPatchOperationType.add);
+            PathHelper.SetValueFromPath(typeof(SimpleEntity), "/foo", entity, "New Value", JsonPatchOperationType.add);
 
             //assert
             Assert.AreEqual("New Value", entity.Foo);
@@ -463,7 +463,7 @@ namespace JsonPatch.Tests
             var entity = new SimpleEntity { };
 
             //act
-            PathHelper.SetValueFromPath(typeof(SimpleEntity), "/Foo", entity, "New Value", JsonPatchOperationType.replace);
+            PathHelper.SetValueFromPath(typeof(SimpleEntity), "/foo", entity, "New Value", JsonPatchOperationType.replace);
 
             //assert
             Assert.AreEqual("New Value", entity.Foo);
@@ -476,7 +476,7 @@ namespace JsonPatch.Tests
             var entity = new SimpleEntity { Foo = "Existing Value" };
 
             //act
-            PathHelper.SetValueFromPath(typeof(SimpleEntity), "/Foo", entity, "New Value", JsonPatchOperationType.replace);
+            PathHelper.SetValueFromPath(typeof(SimpleEntity), "/foo", entity, "New Value", JsonPatchOperationType.replace);
             
             //assert
             Assert.AreEqual("New Value", entity.Foo);
@@ -489,7 +489,7 @@ namespace JsonPatch.Tests
             var entity = new SimpleEntity { };
 
             //act
-            PathHelper.SetValueFromPath(typeof(SimpleEntity), "/Foo", entity, null, JsonPatchOperationType.remove);
+            PathHelper.SetValueFromPath(typeof(SimpleEntity), "/foo", entity, null, JsonPatchOperationType.remove);
 
             //assert
             Assert.AreEqual(null, entity.Foo);
@@ -502,7 +502,7 @@ namespace JsonPatch.Tests
             var entity = new SimpleEntity { Foo = "Existing Value" };
 
             //act
-            PathHelper.SetValueFromPath(typeof(SimpleEntity), "/Foo", entity, null, JsonPatchOperationType.remove);
+            PathHelper.SetValueFromPath(typeof(SimpleEntity), "/foo", entity, null, JsonPatchOperationType.remove);
 
             //assert
             Assert.AreEqual(null, entity.Foo);
@@ -522,7 +522,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ArrayEntity), "/Foo/1", entity, "Element Two Updated", JsonPatchOperationType.replace);
+            PathHelper.SetValueFromPath(typeof(ArrayEntity), "/foo/1", entity, "Element Two Updated", JsonPatchOperationType.replace);
 
             //Assert
             Assert.AreEqual("Element Two Updated", entity.Foo[1]);
@@ -539,7 +539,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/1", entity, "Element Two Updated", JsonPatchOperationType.replace);
+            PathHelper.SetValueFromPath(typeof(ListEntity), "/foo/1", entity, "Element Two Updated", JsonPatchOperationType.replace);
 
             //Assert
             Assert.AreEqual("Element Two Updated", entity.Foo[1]);
@@ -556,7 +556,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ArrayEntity), "/Foo/2", entity, "Element Two Updated", JsonPatchOperationType.replace);
+            PathHelper.SetValueFromPath(typeof(ArrayEntity), "/foo/2", entity, "Element Two Updated", JsonPatchOperationType.replace);
         }
 
         [TestMethod, ExpectedException(typeof(JsonPatchException))]
@@ -569,7 +569,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ArrayEntity), "/Foo/2", entity, "Element Three", JsonPatchOperationType.add);
+            PathHelper.SetValueFromPath(typeof(ArrayEntity), "/foo/2", entity, "Element Three", JsonPatchOperationType.add);
 
             // Arrays should not support resizing. Expect JsonPatchException with an inner exception of type
             // NotSupportedException: Collection was of a fixed size.
@@ -585,7 +585,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/1", entity, "Element Two Updated", JsonPatchOperationType.add);
+            PathHelper.SetValueFromPath(typeof(ListEntity), "/foo/1", entity, "Element Two Updated", JsonPatchOperationType.add);
 
             //Assert
             Assert.AreEqual("Element Two Updated", entity.Foo[1]);
@@ -600,7 +600,7 @@ namespace JsonPatch.Tests
             var entity = new ListEntity();
 
             //act
-            PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/0", entity, "Element One", JsonPatchOperationType.add);
+            PathHelper.SetValueFromPath(typeof(ListEntity), "/foo/0", entity, "Element One", JsonPatchOperationType.add);
         }
 
         [TestMethod]
@@ -613,7 +613,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/2", entity, "Element Two Updated", JsonPatchOperationType.add);
+            PathHelper.SetValueFromPath(typeof(ListEntity), "/foo/2", entity, "Element Two Updated", JsonPatchOperationType.add);
 
             //Assert
             Assert.AreEqual("Element Two Updated", entity.Foo[2]);
@@ -631,7 +631,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ArrayEntity), "/Foo/1", entity, null, JsonPatchOperationType.remove);
+            PathHelper.SetValueFromPath(typeof(ArrayEntity), "/foo/1", entity, null, JsonPatchOperationType.remove);
 
             // Arrays should not support resizing. Expect JsonPatchException with an inner exception of type
             // NotSupportedException: Collection was of a fixed size
@@ -647,7 +647,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/0", entity, null, JsonPatchOperationType.remove);
+            PathHelper.SetValueFromPath(typeof(ListEntity), "/foo/0", entity, null, JsonPatchOperationType.remove);
 
             //Assert
             Assert.AreEqual("Element Two", entity.Foo[0]);
@@ -664,7 +664,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/1", entity, null, JsonPatchOperationType.remove);
+            PathHelper.SetValueFromPath(typeof(ListEntity), "/foo/1", entity, null, JsonPatchOperationType.remove);
 
             //Assert
             Assert.AreEqual("Element One", entity.Foo[0]);
@@ -682,7 +682,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/2", entity, null, JsonPatchOperationType.remove);
+            PathHelper.SetValueFromPath(typeof(ListEntity), "/foo/2", entity, null, JsonPatchOperationType.remove);
         }
 
         #endregion
@@ -696,7 +696,7 @@ namespace JsonPatch.Tests
             var entity = new ComplexEntity { Bar = new SimpleEntity() };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/Bar/Foo", entity, "New Value", JsonPatchOperationType.add);
+            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/bar/foo", entity, "New Value", JsonPatchOperationType.add);
 
             //assert
             Assert.AreEqual("New Value", entity.Bar.Foo);
@@ -709,7 +709,7 @@ namespace JsonPatch.Tests
             var entity = new ComplexEntity { };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/Bar/Foo", entity, "New Value", JsonPatchOperationType.add);
+            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/bar/foo", entity, "New Value", JsonPatchOperationType.add);
         }
 
         [TestMethod]
@@ -725,7 +725,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/Qux/0/Foo", entity, "New Value", JsonPatchOperationType.add);
+            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/qux/0/foo", entity, "New Value", JsonPatchOperationType.add);
 
             //assert
             Assert.AreEqual("New Value", entity.Qux[0].Foo);
@@ -744,7 +744,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/Qux/0/Foo", entity, "New Value", JsonPatchOperationType.replace);
+            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/Qux/0/foo", entity, "New Value", JsonPatchOperationType.replace);
 
             //assert
             Assert.AreEqual("New Value", entity.Qux[0].Foo);
@@ -763,7 +763,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/Qux/0/Foo", entity, null, JsonPatchOperationType.remove);
+            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/qux/0/Foo", entity, null, JsonPatchOperationType.remove);
 
             //assert
             Assert.IsNull(entity.Qux[0].Foo);
@@ -798,7 +798,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/Foo/Foo/0", entity, "Element One - Updated", JsonPatchOperationType.replace);
+            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/foo/foo/0", entity, "Element One - Updated", JsonPatchOperationType.replace);
 
             //assert
             Assert.AreEqual("Element One - Updated", entity.Foo.Foo[0]);
@@ -817,7 +817,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/Foo/Foo/1", entity, "New Value", JsonPatchOperationType.add);
+            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/foo/Foo/1", entity, "New Value", JsonPatchOperationType.add);
         }
 
         [TestMethod]
@@ -836,7 +836,7 @@ namespace JsonPatch.Tests
             };
 
             //act
-            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/Norf/0/Foo/0", entity, "Element One", JsonPatchOperationType.add);
+            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/Norf/0/foo/0", entity, "Element One", JsonPatchOperationType.add);
 
             //assert
             Assert.AreEqual(1, entity.Norf[0].Foo.Count);
@@ -858,7 +858,7 @@ namespace JsonPatch.Tests
             };
 
             // act
-            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/Bar", entity, value, JsonPatchOperationType.add);
+            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/bar", entity, value, JsonPatchOperationType.add);
 
             //assert
             Assert.AreEqual("I am foo", entity.Bar.Foo);
@@ -877,7 +877,7 @@ namespace JsonPatch.Tests
             };
 
             // act
-            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/Foo", entity, value, JsonPatchOperationType.add);
+            PathHelper.SetValueFromPath(typeof(ComplexEntity), "/foo", entity, value, JsonPatchOperationType.add);
 
             //assert
             Assert.AreEqual(3, entity.Foo.Foo.Length);

--- a/src/JsonPatch.Tests/JsonPatch.Tests.csproj
+++ b/src/JsonPatch.Tests/JsonPatch.Tests.csproj
@@ -42,6 +42,7 @@
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -61,6 +62,7 @@
     <Compile Include="Entitys\ListEntity.cs" />
     <Compile Include="Entitys\SimpleEntity.cs" />
     <Compile Include="JsonPatchDocumentTests.cs" />
+    <Compile Include="CaseInsensitivePathHelperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PathHelperTests.cs" />
   </ItemGroup>

--- a/src/JsonPatch.Tests/JsonPatchDocumentTests.cs
+++ b/src/JsonPatch.Tests/JsonPatchDocumentTests.cs
@@ -308,5 +308,55 @@ namespace JsonPatch.Tests
 
         #endregion
 
+        #region JsonPatch HasOperations Tests
+
+        [TestMethod]
+        public void HasOperations_FalseByDefault()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<SimpleEntity>();
+
+            //Assert
+            Assert.IsFalse(patchDocument.HasOperations);
+        }
+
+        [TestMethod]
+        public void Add_ValidPath_SetsHasOperations()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<SimpleEntity>();
+
+            //Act
+            patchDocument.Add("Foo", "bar");
+
+            //Assert
+            Assert.IsTrue(patchDocument.HasOperations);
+        }
+
+        public void Remove_ValidPath_SetsHasOperations()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<SimpleEntity>();
+
+            //Act
+            patchDocument.Remove("Foo");
+
+            //Assert
+            Assert.IsTrue(patchDocument.HasOperations);
+        }
+
+        [TestMethod]
+        public void Replace_ValidPath_SetsHasOperations()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<SimpleEntity>();
+
+            //Act
+            patchDocument.Replace("Foo", "bar");
+
+            //Assert
+            Assert.IsTrue(patchDocument.HasOperations);
+        }
+        #endregion
     }
 }

--- a/src/JsonPatch/Formatting/JsonPatchFormatter.cs
+++ b/src/JsonPatch/Formatting/JsonPatchFormatter.cs
@@ -13,8 +13,15 @@ namespace JsonPatch.Formatting
 {
     public class JsonPatchFormatter : BufferedMediaTypeFormatter
     {
-        public JsonPatchFormatter()
+        internal static JsonPatchSettings Settings { get; private set; }
+        public JsonPatchFormatter() : this(JsonPatchSettings.DefaultPatchSettings())
         {
+            
+        }
+
+        public JsonPatchFormatter(JsonPatchSettings settings)
+        {
+            Settings = settings;
             SupportedMediaTypes.Add(new MediaTypeHeaderValue("application/json-patch+json"));
         }
 

--- a/src/JsonPatch/JsonPatch.csproj
+++ b/src/JsonPatch/JsonPatch.csproj
@@ -54,6 +54,7 @@
     <Compile Include="JsonPatchParseException.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Formatting\JsonPatchFormatter.cs" />
+    <Compile Include="JsonPatchSettings.cs" />
     <Compile Include="Paths\Components\CollectionIndexPathComponent.cs" />
     <Compile Include="Paths\Components\PathComponent.cs" />
     <Compile Include="Paths\PathHelper.cs" />
@@ -64,6 +65,10 @@
     <Compile Include="JsonPatchException.cs" />
     <Compile Include="Model\PatchOperation.cs" />
     <Compile Include="Paths\Components\PropertyPathComponent.cs" />
+    <Compile Include="Paths\Resolvers\BaseResolver.cs" />
+    <Compile Include="Paths\Resolvers\CaseInsensitivePropertyPathResolver.cs" />
+    <Compile Include="Paths\Resolvers\ExactCasePropertyPathResolver.cs" />
+    <Compile Include="Paths\Resolvers\IPathResolver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/JsonPatch/JsonPatchDocument.cs
+++ b/src/JsonPatch/JsonPatchDocument.cs
@@ -10,10 +10,11 @@ namespace JsonPatch
 {
     public class JsonPatchDocument<TEntity> : IJsonPatchDocument where TEntity : class, new()
     {
-
         private List<JsonPatchOperation> _operations = new List<JsonPatchOperation>();
 
         public List<JsonPatchOperation> Operations { get { return _operations; } }
+
+        public bool HasOperations { get { return _operations.Count > 0; } }
 
         public void Add(string path, object value)
         {

--- a/src/JsonPatch/JsonPatchSettings.cs
+++ b/src/JsonPatch/JsonPatchSettings.cs
@@ -1,0 +1,20 @@
+﻿using JsonPatch.Paths.Resolvers;
+
+namespace JsonPatch
+{
+    /// <summary>
+    /// Collection of settings related to JsonPath
+    /// </summary>
+    public class JsonPatchSettings
+    {
+        public IPathResolver PathResolver { get; set; }
+
+        internal static JsonPatchSettings DefaultPatchSettings()
+        {
+            return new JsonPatchSettings
+            {
+                PathResolver = new ExactCasePropertyPathResolver()
+            };
+        }
+    }
+}

--- a/src/JsonPatch/Paths/PathHelper.cs
+++ b/src/JsonPatch/Paths/PathHelper.cs
@@ -1,16 +1,17 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using JsonPatch.Extensions;
-using JsonPatch.Helpers;
+using JsonPatch.Formatting;
 using JsonPatch.Paths.Components;
-using Newtonsoft.Json;
+using JsonPatch.Paths.Resolvers;
 
 namespace JsonPatch.Paths
 {
     public class PathHelper
     {
+        internal static IPathResolver PathResolver
+        {
+            get { return JsonPatchFormatter.Settings.PathResolver; }
+        }
+
         #region Parse/Validate Paths
         
         public static bool IsPathValid(Type entityType, string path)
@@ -28,92 +29,7 @@ namespace JsonPatch.Paths
 
         public static PathComponent[] ParsePath(string path, Type entityType)
         {
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                throw new JsonPatchParseException("Path may not be empty.");
-            }
-
-            // Normalize the path by ensuring it begins with a single forward slash, and has
-            // no trailing slashes. Modify the path variable itself so that any character
-            // positions we report in error messages are accurate.
-            path = "/" + path.Trim('/');
-
-            // Keep track of our current position in the path string (for error reporting).
-            int pos = 1;
-
-            var pathComponents = path.Split('/').Skip(1).ToArray();
-            var parsedComponents = new PathComponent[pathComponents.Length];
-
-            for (int i = 0; i < pathComponents.Length; i++)
-            {
-                var pathComponent = pathComponents[i];
-
-                try
-                {
-                    parsedComponents[i] = ParsePathComponent(pathComponent, entityType,
-                        i > 0 ? parsedComponents[i - 1] : null);
-                }
-                catch (JsonPatchParseException e)
-                {
-                    throw new JsonPatchParseException(string.Format(
-                        "The path \"{0}\" is not valid: {1}\n" +
-                        "(Error occurred while parsing path component \"{2}\" at character position {3}.)",
-                        path, e.Message, pathComponent, pos), e);
-                }
-
-                pos += pathComponent.Length + 1;
-            }
-
-            return parsedComponents;
-        }
-
-        private static PathComponent ParsePathComponent(string component, Type rootEntityType, PathComponent previous = null)
-        {
-            if (string.IsNullOrWhiteSpace(component))
-            {
-                throw new JsonPatchParseException("Path component may not be empty.");
-            }
-
-            // If the path component is a positive integer, it represents a collection index.
-            if (component.IsPositiveInteger())
-            {
-                if (previous == null)
-                {
-                    throw new JsonPatchParseException("The first path component may not be a collection index.");
-                }
-
-                if (!previous.IsCollection)
-                {
-                    throw new JsonPatchParseException(string.Format(
-                        "Collection index (\"{0}\") is not valid here because the previous path component (\"{1}\") " +
-                        "does not represent a collection type.",
-                        component, previous.Name));
-                }
-
-                return new CollectionIndexPathComponent(component)
-                {
-                    CollectionIndex = component.ToInt32(),
-                    ComponentType = GetCollectionType(previous.ComponentType)
-                };
-            }
-
-            // Otherwise, the path component represents a property name.
-
-            // Attempt to retrieve the corresponding property.
-            Type parentType = (previous == null) ? rootEntityType : previous.ComponentType;
-            var property = parentType.GetProperty(component);
-
-            if (property == null)
-            {
-                throw new JsonPatchParseException(string.Format("There is no property named \"{0}\" on type {1}.",
-                    component, parentType.Name));
-            }
-
-            return new PropertyPathComponent(component)
-            {
-                PropertyInfo = property,
-                ComponentType = property.PropertyType
-            };
+            return PathResolver.ParsePath(path, entityType);
         }
 
         #endregion
@@ -127,56 +43,7 @@ namespace JsonPatch.Paths
 
         public static object GetValueFromPath(Type entityType, PathComponent[] pathComponents, object entity)
         {
-            try
-            {
-                if (entity == null)
-                {
-                    throw new JsonPatchException("The root object is null.");
-                }
-
-                object previous = entity;
-
-                for (int i = 0; i < pathComponents.Length; i++)
-                {
-                    string parentPath = PathComponent.GetFullPath(pathComponents.Take(i));
-                    var pathComponent = pathComponents[i];
-
-                    TypeSwitch.On(pathComponent)
-                        .Case((PropertyPathComponent component) =>
-                        {
-                            if (previous == null)
-                            {
-                                throw new JsonPatchException(string.Format(
-                                    "Cannot get property \"{0}\" from null object at path \"{1}\".",
-                                    component.Name, parentPath));
-                            }
-
-                            previous = component.PropertyInfo.GetValue(previous);
-                        })
-                        .Case((CollectionIndexPathComponent component) =>
-                        {
-                            try
-                            {
-                                var list = (IList) previous;
-                                previous = list[component.CollectionIndex];
-                            }
-                            catch (Exception e)
-                            {
-                                throw new JsonPatchException(string.Format(
-                                    "Cannot access index {0} from collection at path \"{1}\".",
-                                    component.CollectionIndex, parentPath), e);
-                            }
-                        });
-                }
-
-                return previous;
-            }
-            catch (Exception e)
-            {
-                throw new JsonPatchException(string.Format(
-                    "Failed to get value from path \"{0}\": {1}",
-                    PathComponent.GetFullPath(pathComponents), e.Message), e);
-            }
+            return PathResolver.GetValueFromPath(entityType, pathComponents, entity);
         }
 
         #endregion
@@ -190,80 +57,7 @@ namespace JsonPatch.Paths
 
         public static void SetValueFromPath(Type entityType, PathComponent[] pathComponents, object entity, object value, JsonPatchOperationType operationType)
         {
-            try
-            {
-                PathComponent[] parent = pathComponents.Take(pathComponents.Length - 1).ToArray();
-                string parentPath = PathComponent.GetFullPath(parent);
-
-                object previous = GetValueFromPath(entityType, parent, entity);
-
-                if (previous == null)
-                {
-                    throw new JsonPatchException(string.Format("Value at parent path \"{0}\" is null.", parentPath));
-                }
-
-                var target = pathComponents.Last();
-
-                TypeSwitch.On(target)
-                    .Case((PropertyPathComponent component) =>
-                    {
-                        switch (operationType)
-                        {
-                            case JsonPatchOperationType.add:
-                            case JsonPatchOperationType.replace:
-                                component.PropertyInfo.SetValue(previous, ConvertValue(value, component.ComponentType));
-                                break;
-                            case JsonPatchOperationType.remove:
-                                component.PropertyInfo.SetValue(previous, null);
-                                break;
-                            default:
-                                throw new ArgumentOutOfRangeException("operationType");
-                        }
-                    })
-                    .Case((CollectionIndexPathComponent component) =>
-                    {
-                        var list = previous as IList;
-                        if (list == null)
-                        {
-                            throw new JsonPatchException(string.Format("Value at parent path \"{0}\" is not a valid collection.", parentPath));
-                        }
-
-                        switch (operationType)
-                        {
-                            case JsonPatchOperationType.add:
-                                list.Insert(component.CollectionIndex, ConvertValue(value, component.ComponentType));
-                                break;
-                            case JsonPatchOperationType.remove:
-                                list.RemoveAt(component.CollectionIndex);
-                                break;
-                            case JsonPatchOperationType.replace:
-                                list[component.CollectionIndex] = ConvertValue(value, component.ComponentType);
-                                break;
-                            default:
-                                throw new ArgumentOutOfRangeException("operationType");
-                        }
-                    });
-            }
-            catch (Exception e)
-            {
-                throw new JsonPatchException(string.Format(
-                    "Failed to set value at path \"{0}\" while performing \"{1}\" operation: {2}",
-                    PathComponent.GetFullPath(pathComponents), operationType, e.Message), e);
-            }
-        }
-
-        #endregion
-
-        #region Helpers
-
-        private static Type GetCollectionType(Type entityType)
-        {
-            return entityType.GetElementType() ?? entityType.GetGenericArguments().First();
-        }
-
-        private static object ConvertValue(object value, Type type)
-        {
-            return JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), type);
+            PathResolver.SetValueFromPath(entityType, pathComponents, entity, value, operationType);
         }
 
         #endregion

--- a/src/JsonPatch/Paths/PathHelper.cs
+++ b/src/JsonPatch/Paths/PathHelper.cs
@@ -9,7 +9,12 @@ namespace JsonPatch.Paths
     {
         internal static IPathResolver PathResolver
         {
-            get { return JsonPatchFormatter.Settings.PathResolver; }
+            get
+            {
+                return JsonPatchFormatter.Settings == null
+                    ? JsonPatchSettings.DefaultPatchSettings().PathResolver
+                    : JsonPatchFormatter.Settings.PathResolver;
+            }
         }
 
         #region Parse/Validate Paths

--- a/src/JsonPatch/Paths/Resolvers/BaseResolver.cs
+++ b/src/JsonPatch/Paths/Resolvers/BaseResolver.cs
@@ -1,0 +1,231 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+
+using JsonPatch.Extensions;
+using JsonPatch.Helpers;
+using JsonPatch.Paths.Components;
+using Newtonsoft.Json;
+
+namespace JsonPatch.Paths.Resolvers
+{
+    public abstract class BaseResolver : IPathResolver
+    {
+        protected abstract PropertyInfo GetProperty(Type parentType, string component);
+
+        protected abstract string[] GetPathComponents(string path);
+
+        public PathComponent ParsePathComponent(string component, Type rootEntityType, PathComponent previous = null)
+        {
+            if (string.IsNullOrWhiteSpace(component))
+            {
+                throw new JsonPatchParseException("Path component may not be empty.");
+            }
+
+            // If the path component is a positive integer, it represents a collection index.
+            if (component.IsPositiveInteger())
+            {
+                if (previous == null)
+                {
+                    throw new JsonPatchParseException("The first path component may not be a collection index.");
+                }
+
+                if (!previous.IsCollection)
+                {
+                    throw new JsonPatchParseException(string.Format(
+                        "Collection index (\"{0}\") is not valid here because the previous path component (\"{1}\") " +
+                        "does not represent a collection type.",
+                        component, previous.Name));
+                }
+
+                return new CollectionIndexPathComponent(component)
+                {
+                    CollectionIndex = component.ToInt32(),
+                    ComponentType = GetCollectionType(previous.ComponentType)
+                };
+            }
+
+            // Otherwise, the path component represents a property name.
+
+            // Attempt to retrieve the corresponding property.
+            Type parentType = (previous == null) ? rootEntityType : previous.ComponentType;
+            var property = GetProperty(parentType, component);
+
+            if (property == null)
+            {
+                throw new JsonPatchParseException(string.Format("There is no property named \"{0}\" on type {1}.",
+                    component, parentType.Name));
+            }
+
+            return new PropertyPathComponent(component)
+            {
+                PropertyInfo = property,
+                ComponentType = property.PropertyType
+            };
+        }
+
+        public PathComponent[] ParsePath(string path, Type entityType)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new JsonPatchParseException("Path may not be empty.");
+            }
+
+            var pathComponents = GetPathComponents(path);
+            var parsedComponents = new PathComponent[pathComponents.Length];
+
+            // Keep track of our current position in the path string (for error reporting).
+            int pos = 1;
+            for (int i = 0; i < pathComponents.Length; i++)
+            {
+                var pathComponent = pathComponents[i];
+
+                try
+                {
+                    parsedComponents[i] = ParsePathComponent(pathComponent, entityType,
+                        i > 0 ? parsedComponents[i - 1] : null);
+                }
+                catch (JsonPatchParseException e)
+                {
+                    throw new JsonPatchParseException(string.Format(
+                        "The path \"{0}\" is not valid: {1}\n" +
+                        "(Error occurred while parsing path component \"{2}\" at character position {3}.)",
+                        path, e.Message, pathComponent, pos), e);
+                }
+
+                pos += pathComponent.Length + 1;
+            }
+
+            return parsedComponents;
+        }
+
+        public object GetValueFromPath(Type entityType, PathComponent[] pathComponents, object entity)
+        {
+            try
+            {
+                if (entity == null)
+                {
+                    throw new JsonPatchException("The root object is null.");
+                }
+
+                object previous = entity;
+
+                for (int i = 0; i < pathComponents.Length; i++)
+                {
+                    string parentPath = PathComponent.GetFullPath(pathComponents.Take(i));
+                    var pathComponent = pathComponents[i];
+
+                    TypeSwitch.On(pathComponent)
+                        .Case((PropertyPathComponent component) =>
+                        {
+                            if (previous == null)
+                            {
+                                throw new JsonPatchException(string.Format(
+                                    "Cannot get property \"{0}\" from null object at path \"{1}\".",
+                                    component.Name, parentPath));
+                            }
+
+                            previous = component.PropertyInfo.GetValue(previous);
+                        })
+                        .Case((CollectionIndexPathComponent component) =>
+                        {
+                            try
+                            {
+                                var list = (IList)previous;
+                                previous = list[component.CollectionIndex];
+                            }
+                            catch (Exception e)
+                            {
+                                throw new JsonPatchException(string.Format(
+                                    "Cannot access index {0} from collection at path \"{1}\".",
+                                    component.CollectionIndex, parentPath), e);
+                            }
+                        });
+                }
+
+                return previous;
+            }
+            catch (Exception e)
+            {
+                throw new JsonPatchException(string.Format(
+                    "Failed to get value from path \"{0}\": {1}",
+                    PathComponent.GetFullPath(pathComponents), e.Message), e);
+            }
+        }
+
+        public void SetValueFromPath(Type entityType, PathComponent[] pathComponents, object entity, object value, JsonPatchOperationType operationType)
+        {
+            try
+            {
+                PathComponent[] parent = pathComponents.Take(pathComponents.Length - 1).ToArray();
+                string parentPath = PathComponent.GetFullPath(parent);
+
+                object previous = GetValueFromPath(entityType, parent, entity);
+
+                if (previous == null)
+                {
+                    throw new JsonPatchException(string.Format("Value at parent path \"{0}\" is null.", parentPath));
+                }
+
+                var target = pathComponents.Last();
+
+                TypeSwitch.On(target)
+                    .Case((PropertyPathComponent component) =>
+                    {
+                        switch (operationType)
+                        {
+                            case JsonPatchOperationType.add:
+                            case JsonPatchOperationType.replace:
+                                component.PropertyInfo.SetValue(previous, ConvertValue(value, component.ComponentType));
+                                break;
+                            case JsonPatchOperationType.remove:
+                                component.PropertyInfo.SetValue(previous, null);
+                                break;
+                            default:
+                                throw new ArgumentOutOfRangeException("operationType");
+                        }
+                    })
+                    .Case((CollectionIndexPathComponent component) =>
+                    {
+                        var list = previous as IList;
+                        if (list == null)
+                        {
+                            throw new JsonPatchException(string.Format("Value at parent path \"{0}\" is not a valid collection.", parentPath));
+                        }
+
+                        switch (operationType)
+                        {
+                            case JsonPatchOperationType.add:
+                                list.Insert(component.CollectionIndex, ConvertValue(value, component.ComponentType));
+                                break;
+                            case JsonPatchOperationType.remove:
+                                list.RemoveAt(component.CollectionIndex);
+                                break;
+                            case JsonPatchOperationType.replace:
+                                list[component.CollectionIndex] = ConvertValue(value, component.ComponentType);
+                                break;
+                            default:
+                                throw new ArgumentOutOfRangeException("operationType");
+                        }
+                    });
+            }
+            catch (Exception e)
+            {
+                throw new JsonPatchException(string.Format(
+                    "Failed to set value at path \"{0}\" while performing \"{1}\" operation: {2}",
+                    PathComponent.GetFullPath(pathComponents), operationType, e.Message), e);
+            }
+        }
+
+        private static Type GetCollectionType(Type entityType)
+        {
+            return entityType.GetElementType() ?? entityType.GetGenericArguments().First();
+        }
+
+        private static object ConvertValue(object value, Type type)
+        {
+            return JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), type);
+        }
+    }
+}

--- a/src/JsonPatch/Paths/Resolvers/CaseInsensitivePropertyPathResolver.cs
+++ b/src/JsonPatch/Paths/Resolvers/CaseInsensitivePropertyPathResolver.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace JsonPatch.Paths.Resolvers
+{
+    /// <summary>
+    /// Case insensitive path resolver
+    /// </summary>
+    public class CaseInsensitivePropertyPathResolver : BaseResolver
+    {
+        protected override PropertyInfo GetProperty(Type parentType, string component)
+        {
+            return parentType.GetProperty(component,
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+        }
+
+        protected override string[] GetPathComponents(string path)
+        {
+            // Normalize the path by ensuring it begins with a single forward slash, and has
+            // no trailing slashes. Modify the path variable itself so that any character
+            // positions we report in error messages are accurate.
+
+            path = "/" + path.ToLowerInvariant().Trim('/');
+
+            return path.Split('/').Skip(1).Select(s => s.ToLowerInvariant()).ToArray();
+        }
+    }
+}

--- a/src/JsonPatch/Paths/Resolvers/ExactCasePropertyPathResolver.cs
+++ b/src/JsonPatch/Paths/Resolvers/ExactCasePropertyPathResolver.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace JsonPatch.Paths.Resolvers
+{
+    /// <summary>
+    /// Implementation of path resolver that will only match on exact case
+    /// </summary>
+    public class ExactCasePropertyPathResolver : BaseResolver
+    {
+        protected override PropertyInfo GetProperty(Type parentType, string component)
+        {
+            return parentType.GetProperty(component);
+        }
+
+        protected override string[] GetPathComponents(string path)
+        {
+            // Normalize the path by ensuring it begins with a single forward slash, and has
+            // no trailing slashes. Modify the path variable itself so that any character
+            // positions we report in error messages are accurate.
+
+            path = "/" + path.Trim('/');
+
+            return path.Split('/').Skip(1).ToArray();
+        }
+    }
+}

--- a/src/JsonPatch/Paths/Resolvers/IPathResolver.cs
+++ b/src/JsonPatch/Paths/Resolvers/IPathResolver.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+using JsonPatch.Paths.Components;
+
+namespace JsonPatch.Paths.Resolvers
+{
+    public interface IPathResolver
+    {
+        PathComponent[] ParsePath(string path, Type entityType);
+
+        PathComponent ParsePathComponent(string component, Type rootEntityType, PathComponent previous = null);
+
+        object GetValueFromPath(Type entityType, PathComponent[] pathComponents, object entity);
+
+        void SetValueFromPath(Type entityType, PathComponent[] pathComponents, object entity, object value,
+            JsonPatchOperationType operationType);
+    }
+}


### PR DESCRIPTION
Created an IPathResolver which can be set in new JsonPatchSettings class. By default this will be case sensitive.

I've added 2 IPathResolver implementations for now:
- CaseInsensitivePropertyPathResolver
- ExactCasePropertyPathResolver (default)

To specify a different one pass a JsonPathSettings object to formatter, e.g.:

```csharp
new JsonPatchFormatter(new JsonPatchSettings 
{
  PathResolver = new CaseInsensitivePropertyPathResolver()
});
```