### PR TITLE
case insensitive fallback + datamember and jsonproperty support.

### DIFF
--- a/src/JsonPatch.Tests/Entitys/SimpleEntity.cs
+++ b/src/JsonPatch.Tests/Entitys/SimpleEntity.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace JsonPatch.Tests.Entitys
 {
@@ -11,5 +13,11 @@ namespace JsonPatch.Tests.Entitys
         public string Foo { get; set; }
         public int Bar { get; set; }
         public string Baz { get; set; }
+
+        [DataMember(Name = "pId")]       
+        public string ParId { get; set; }
+
+        [JsonProperty("jsonProperty")]
+        public string Car { get; set; }
     }
 }

--- a/src/JsonPatch.Tests/JsonPatch.Tests.csproj
+++ b/src/JsonPatch.Tests/JsonPatch.Tests.csproj
@@ -42,6 +42,7 @@
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/src/JsonPatch.Tests/PathHelperTests.cs
+++ b/src/JsonPatch.Tests/PathHelperTests.cs
@@ -85,6 +85,20 @@ namespace JsonPatch.Tests
             PathHelper.ParsePath("/Bar/5", typeof(SimpleEntity));
         }
 
+        [TestMethod]
+        public void ParsePath_DataMember_ParsesSuccessfully() {
+            PathHelper.ParsePath("pId", typeof(SimpleEntity));
+        }
+
+        [TestMethod]
+        public void ParsePath_JsonProperty_ParsesSuccessfully() {
+            PathHelper.ParsePath("jsonProperty", typeof(SimpleEntity));
+        }
+
+        [TestMethod]
+        public void ParsePath_CaseInsensitive_FallbackSuccessful() {
+            PathHelper.ParsePath("bar", typeof(SimpleEntity));
+        }
         #endregion
 
         #region IsPathValid

--- a/src/JsonPatch/JsonPatch.csproj
+++ b/src/JsonPatch/JsonPatch.csproj
@@ -42,6 +42,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>packages\Microsoft.AspNet.WebApi.Client.5.2.0\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
added functionality based on issue https://github.com/myquay/JsonPatch/issues/19  that I created.

ParseProperty will now check for [DataMember] and [JsonProperty] attributes, as well as fallback to case-insensitive checks if it does not find exact matches.  

Added 3 new tests to verify new scenarios.
