### PR TITLE
#8 - added support of `-` character for add methods for collections

### DIFF
--- a/src/JsonPatch.Tests/PathHelperTests.cs
+++ b/src/JsonPatch.Tests/PathHelperTests.cs
@@ -102,6 +102,21 @@ namespace JsonPatch.Tests
             Assert.AreEqual(typeof(string), pathComponents[1].ComponentType);
         }
 
+        [TestMethod]
+        public void ParsePath_CollectionAdd_ParsesSuccessfully()
+        {
+            //act
+            var pathComponents = PathHelper.ParsePath("/Foo/-", typeof(ListEntity));
+
+            //assert
+            Assert.AreEqual(2, pathComponents.Length);
+            Assert.AreEqual("Foo", pathComponents[0].Name);
+            Assert.IsTrue(pathComponents[0].IsCollection);
+            Assert.AreEqual("-", pathComponents[1].Name);
+            Assert.IsInstanceOfType(pathComponents[1], typeof(CollectionPathComponent));
+            Assert.AreEqual(typeof(string), pathComponents[1].ComponentType);
+        }
+
         [TestMethod, ExpectedException(typeof(JsonPatchParseException))]
         public void ParsePath_CollectionIndexAfterNonCollectionProperty_ParsesSuccessfully()
         {
@@ -584,7 +599,7 @@ namespace JsonPatch.Tests
         }
 
         [TestMethod]
-        public void SetValueFromPath_AddListValue_AddsValue()
+        public void SetValueFromPath_AddListValueByIndex_InsertsValue()
         {
             //Arrange
             var entity = new ListEntity
@@ -598,6 +613,23 @@ namespace JsonPatch.Tests
             //Assert
             Assert.AreEqual("Element Two Updated", entity.Foo[1]);
             Assert.AreEqual("Element Two", entity.Foo[2]);
+            Assert.AreEqual(3, entity.Foo.Count);
+        }
+
+        [TestMethod]
+        public void SetValueFromPath_AddListValue_AddsValue()
+        {
+            //Arrange
+            var entity = new ListEntity
+            {
+                Foo = new List<string> { "Element One", "Element Two" }
+            };
+
+            //act
+            PathHelper.SetValueFromPath(typeof(ListEntity), "/Foo/-", entity, "Element Three", JsonPatchOperationType.add);
+
+            //Assert
+            Assert.AreEqual("Element Three", entity.Foo[2]);
             Assert.AreEqual(3, entity.Foo.Count);
         }
 

--- a/src/JsonPatch/JsonPatch.csproj
+++ b/src/JsonPatch/JsonPatch.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Formatting\JsonPatchFormatter.cs" />
     <Compile Include="JsonPatchSettings.cs" />
+    <Compile Include="Paths\Components\CollectionPathComponent.cs" />
     <Compile Include="Paths\Components\CollectionIndexPathComponent.cs" />
     <Compile Include="Paths\Components\PathComponent.cs" />
     <Compile Include="Paths\PathHelper.cs" />

--- a/src/JsonPatch/Paths/Components/CollectionPathComponent.cs
+++ b/src/JsonPatch/Paths/Components/CollectionPathComponent.cs
@@ -1,0 +1,10 @@
+﻿namespace JsonPatch.Paths.Components
+{
+    public class CollectionPathComponent : PathComponent
+    {
+        public CollectionPathComponent(string name)
+            : base(name)
+        {
+        }
+    }
+}

--- a/src/JsonPatch/Paths/PathHelper.cs
+++ b/src/JsonPatch/Paths/PathHelper.cs
@@ -35,7 +35,7 @@ namespace JsonPatch.Paths
         public static PathComponent[] ParsePath(string path, Type entityType)
         {
             return PathResolver.ParsePath(path, entityType);
-            }
+        }
 
         #endregion
 


### PR DESCRIPTION
It looks like there were some unix-style line endings in some files so that's why it shows that the whole file was changed but actually the fix is small.
I added a unit test for the fix as well and the tests are green
The fix is for issue #8 