### PR TITLE
Support for 'test' operation

### DIFF
--- a/src/JsonPatch.Tests/JsonPatchDocumentTests.cs
+++ b/src/JsonPatch.Tests/JsonPatchDocumentTests.cs
@@ -145,6 +145,34 @@ namespace JsonPatch.Tests
 
         #endregion
 
+        #region JsonPatch Test Tests
+
+        [TestMethod]
+        public void Test_ValidPath_OperationAdded()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<SimpleEntity>();
+
+            //Act
+            patchDocument.Test("Foo", "bar");
+
+            //Assert
+            Assert.AreEqual(1, patchDocument.Operations.Count);
+            Assert.AreEqual(JsonPatchOperationType.test, patchDocument.Operations.Single().Operation);
+        }
+
+        [TestMethod, ExpectedException(typeof(JsonPatchParseException))]
+        public void Test_InvalidPath_ThrowsJsonPatchParseException()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<SimpleEntity>();
+
+            //Act
+            patchDocument.Test("FooMissing", "bar");
+        }
+
+        #endregion
+
         #region JsonPatch ApplyUpdatesTo Tests
 
         #region Add Operation
@@ -306,6 +334,42 @@ namespace JsonPatch.Tests
 
         #endregion
 
+        #region Test Operation
+
+        [TestMethod]
+        public void ApplyUpdate_TestOperation_ConditionPassed_EntityUpdated()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<SimpleEntity>();
+            var entity = new SimpleEntity { Foo = "bar" };
+
+            //Act
+            patchDocument.Test("Foo", "bar");
+            patchDocument.Replace("Foo", "baz");
+            patchDocument.ApplyUpdatesTo(entity);
+
+            //Assert
+            Assert.AreEqual("baz", entity.Foo);
+        }
+
+        [TestMethod]
+        public void ApplyUpdate_TestOperation_ConditionFailed_EntityNotUpdated()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<SimpleEntity>();
+            var entity = new SimpleEntity { Foo = "not bar" };
+
+            //Act
+            patchDocument.Test("Foo", "bar");
+            patchDocument.Replace("Foo", "baz");
+            patchDocument.ApplyUpdatesTo(entity);
+
+            //Assert
+            Assert.AreNotEqual("baz", entity.Foo);
+        }
+
+        #endregion
+
         #endregion
 
         #region JsonPatch HasOperations Tests
@@ -358,5 +422,6 @@ namespace JsonPatch.Tests
             Assert.IsTrue(patchDocument.HasOperations);
         }
         #endregion
+
     }
 }

--- a/src/JsonPatch/JsonPatchDocument.cs
+++ b/src/JsonPatch/JsonPatchDocument.cs
@@ -60,8 +60,25 @@ namespace JsonPatch
             });
         }
 
+        public void Test(string path, object value)
+        {
+            _operations.Add(new JsonPatchOperation
+            {
+                Operation = JsonPatchOperationType.test,
+                Path = path,
+                ParsedPath = PathHelper.ParsePath(path, typeof(TEntity)),
+                Value = value
+            });
+        }
+
         public void ApplyUpdatesTo(TEntity entity)
         {
+            var preconditions = _operations.Where(operation => operation.Operation == JsonPatchOperationType.test);
+            if (preconditions.Any(operation => AreNotEqual(entity, operation)))
+            {
+                return;
+            }
+
             foreach (var operation in _operations)
             {
                 switch (operation.Operation)
@@ -80,10 +97,17 @@ namespace JsonPatch
                         PathHelper.SetValueFromPath(typeof(TEntity), operation.ParsedFromPath, entity, null, JsonPatchOperationType.remove);
                         PathHelper.SetValueFromPath(typeof(TEntity), operation.ParsedPath, entity, value, JsonPatchOperationType.add);
                         break;
+                    case JsonPatchOperationType.test:
+                        break;
                     default:
                         throw new NotSupportedException("Operation not supported: " + operation.Operation);
                 }
             }
+        }
+
+        private static bool AreNotEqual(TEntity entity, JsonPatchOperation operation)
+        {
+            return PathHelper.GetValueFromPath(typeof(TEntity), operation.ParsedPath, entity) != operation.Value;
         }
     }
 }

--- a/src/JsonPatch/JsonPatchOperationType.cs
+++ b/src/JsonPatch/JsonPatchOperationType.cs
@@ -11,6 +11,7 @@ namespace JsonPatch
         add = 0,
         remove = 1,
         replace = 2,
-        move = 3
+        move = 3,
+        test = 4
     }
 }


### PR DESCRIPTION
Support for 'test' operation. 

See http://jsonpatch.com/#test . 

Test operations that are not equal to the entity values cause `ApplyUpdatesTo(...)` to abort, returning early.

### Details
**src/JsonPatch/JsonPatchDocument.cs**

New public `Test` Method to add an operation to the `JsonPatchDocument`.

Modified public `ApplyUpdatesTo` Method to check test operations before processing the operations.

New private method `AreNotEqual` to check the test operation against the entity.

**src/JsonPatch/JsonPatchOperationType.cs**

Added new value `test` to enum.
