### PR TITLE
Remove System.Json.Text from legacy framework, hard dependency on New…

### DIFF
--- a/src/JsonPatch.Tests/CaseInsensitivePathHelperTests.cs
+++ b/src/JsonPatch.Tests/CaseInsensitivePathHelperTests.cs
@@ -441,7 +441,7 @@ namespace JsonPatch.Tests
             var document = JsonDocument.Parse("true");
 
             //act
-            resolver.SetValueFromPath(typeof(SimpleEntity), "/booleanValue", entity, document.RootElement, JsonPatchOperationType.add);
+            resolver.SetValueFromPath(typeof(SimpleEntity), "/booleanValue", entity, document.RootElement.GetBoolean(), JsonPatchOperationType.add);
 
             //assert
             Assert.AreEqual(true, entity.BooleanValue);

--- a/src/JsonPatch.nuspec
+++ b/src/JsonPatch.nuspec
@@ -12,7 +12,7 @@
 		<projectUrl>https://github.com/myquay/JsonPatch</projectUrl>
 		<repository type="git" url="https://github.com/myquay/JsonPatch.git" branch="master" commit="$commit$" />
 		<description>
-JsonPatch support for ASP.NET Core 6 including support for ASP.NET Minimal APIs. Legacy support for ASP.NET Web API 2 (.NET Framework 4.8).
+JsonPatch support for ASP.NET Core 6 including support for ASP.NET Minimal APIs. Legacy support for ASP.NET MVC (.NET Framework 4.8).
 
 There are no external dependencies for the .NET 6 version and minimal dependencies for the .NET Framework Version.
 
@@ -36,7 +36,6 @@ $releasenotes$
 			<group targetFramework="net48">
 				<dependency id="Newtonsoft.Json" version="13.0.1" />
 				<dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.9" />
-				<dependency id="System.Text.Json" version="7.0.3" />
 			</group>
 			<group targetFramework="net6.0"></group>
 		</dependencies>

--- a/src/JsonPatch/Formatting/JsonPatchFormatter.cs
+++ b/src/JsonPatch/Formatting/JsonPatchFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using JsonPatch.Model;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -6,7 +7,6 @@ using System.Linq;
 using System.Net.Http.Formatting;
 using System.Net.Http.Headers;
 using System.Text;
-using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace JsonPatch.Formatting
@@ -54,7 +54,7 @@ namespace JsonPatch.Formatting
                     .Invoke(null);
 
                 var jsonString = reader.ReadToEnd();
-                var operations = JsonSerializer.Deserialize<PatchOperation[]>(jsonString);
+                var operations = JsonConvert.DeserializeObject<PatchOperation[]>(jsonString);
 
                 foreach (var operation in operations)
                 {

--- a/src/JsonPatch/JsonPatch.csproj
+++ b/src/JsonPatch/JsonPatch.csproj
@@ -37,44 +37,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bcl.AsyncInterfaces.7.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
-    </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
-    </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.9\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Text.Encodings.Web, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Text.Encodings.Web.7.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Text.Json, Version=7.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Text.Json.7.0.3\lib\net462\System.Text.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/JsonPatch/JsonValueConverter.cs
+++ b/src/JsonPatch/JsonValueConverter.cs
@@ -1,10 +1,10 @@
 ﻿using JsonPatch.Paths;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace JsonPatch
@@ -23,7 +23,7 @@ namespace JsonPatch
             }
             else
             {
-                return JsonSerializer.Deserialize(JsonSerializer.Serialize(value), type);
+                return JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), type);
             }
         }
     }

--- a/src/JsonPatch/JsonValueConverter.cs
+++ b/src/JsonPatch/JsonValueConverter.cs
@@ -1,5 +1,6 @@
 ﻿using JsonPatch.Paths;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/JsonPatch/packages.config
+++ b/src/JsonPatch/packages.config
@@ -1,14 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.9" targetFramework="net48" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
-  <package id="System.Memory" version="4.5.5" targetFramework="net48" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
-  <package id="System.Text.Encodings.Web" version="7.0.0" targetFramework="net48" />
-  <package id="System.Text.Json" version="7.0.3" targetFramework="net48" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
…tonsoft.Json means there cannot be a replacement.