### PR TITLE
Improve BaseResolver Thrown Exceptions

### DIFF
--- a/src/JsonPatch.Common/JsonPatchOperationException.cs
+++ b/src/JsonPatch.Common/JsonPatchOperationException.cs
@@ -1,0 +1,59 @@
+﻿using System;
+
+namespace JsonPatch
+{
+    /// <summary>
+    /// Raised when an error occurs while processing changes. Includes extra details about what was being processed.
+    /// </summary>
+    public class JsonPatchOperationException : JsonPatchException
+    {
+        /// <summary>
+        /// Json Patch Operation Type
+        /// </summary>
+        public JsonPatchOperationType operationType;
+
+        /// <summary>
+        /// Path of field being changed
+        /// </summary>
+        public string path;
+
+        /// <summary>
+        /// Underlying type of field
+        /// </summary>
+        public Type entityType;
+
+        /// <summary>
+        /// Value used for operation
+        /// </summary>
+        public object value;
+
+        /// <summary>
+        /// New instance of JsonPatchOperationException with message
+        /// </summary>
+        /// <param name="message"></param>
+        public JsonPatchOperationException(string message) : base(message) { }
+
+        /// <summary>
+        /// New instance of JsonPatchOperationException with message and inner exception
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="innerException"></param>
+        public JsonPatchOperationException(string message, Exception innerException) : base(message, innerException) { }
+
+        /// <summary>
+        /// New instance of JsonPatchOperationException with message and details of operation
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="operationType"></param>
+        /// <param name="path"></param>
+        /// <param name="entityType"></param>
+        /// <param name="value"></param>
+        public JsonPatchOperationException(string message, JsonPatchOperationType operationType, string path, Type entityType, object value) : this(message)
+        {
+            this.operationType = operationType;
+            this.path = path;
+            this.entityType = entityType;
+            this.value = value;
+        }
+    }
+}

--- a/src/JsonPatch.Tests/CaseInsensitivePathHelperTests.cs
+++ b/src/JsonPatch.Tests/CaseInsensitivePathHelperTests.cs
@@ -552,7 +552,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual(2, entity.Foo.Count);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_ReplaceIndexOutOfBounds_ThrowsException()
         {
             //Arrange
@@ -565,7 +565,7 @@ namespace JsonPatch.Tests
             resolver.SetValueFromPath(typeof(ArrayEntity), "/foo/2", entity, "Element Two Updated", JsonPatchOperationType.replace);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_AddArrayValue_ThrowsError()
         {
             //Arrange
@@ -577,11 +577,11 @@ namespace JsonPatch.Tests
             //act
             resolver.SetValueFromPath(typeof(ArrayEntity), "/foo/2", entity, "Element Three", JsonPatchOperationType.add);
 
-            // Arrays should not support resizing. Expect JsonPatchException with an inner exception of type
+            // Arrays should not support resizing. Expect JsonPatchOperationException with an inner exception of type
             // NotSupportedException: Collection was of a fixed size.
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_RemoveArrayValue_ThrowsException()
         {
             //Arrange
@@ -593,7 +593,7 @@ namespace JsonPatch.Tests
             //act
             resolver.SetValueFromPath(typeof(ArrayEntity), "/foo/1", entity, null, JsonPatchOperationType.remove);
 
-            // Arrays should not support resizing. Expect JsonPatchException with an inner exception of type
+            // Arrays should not support resizing. Expect JsonPatchOperationException with an inner exception of type
             // NotSupportedException: Collection was of a fixed size
         }
 
@@ -619,7 +619,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual(3, entity.Foo.Count);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_AddToNullList_ThrowsException()
         {
             //Arrange
@@ -682,7 +682,7 @@ namespace JsonPatch.Tests
         }
 
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_RemoveIndexOutOfBounds_ThrowsException()
         {
             //Arrange
@@ -752,7 +752,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual(3, entity.Foo.Count);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_AddDictionaryValue_ThrowsForExistingKey()
         {
             //Arrange
@@ -798,7 +798,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual(2, entity.Foo.Count);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_AddToNullDictionary_ThrowsException()
         {
             //Arrange
@@ -827,7 +827,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual("New Value", entity.Bar.Foo);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_NullParent_ThrowsException()
         {
             //arrange
@@ -894,7 +894,7 @@ namespace JsonPatch.Tests
             Assert.IsNull(entity.Qux[0].Foo);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_AddToListItemOutOfBounds_ThrowsException()
         {
             //arrange
@@ -929,7 +929,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual("Element One - Updated", entity.Foo.Foo[0]);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_AddToNestedArray_ThrowsException()
         {
             //arrange

--- a/src/JsonPatch.Tests/Entitys/EnumNullableEntity.cs
+++ b/src/JsonPatch.Tests/Entitys/EnumNullableEntity.cs
@@ -1,0 +1,14 @@
+﻿namespace JsonPatch.Tests.Entitys
+{
+    public class EnumNullableEntity
+    {
+        public SampleNullableEnum? Foo { get; set; }
+    }
+
+    public enum SampleNullableEnum
+    {
+        FirstEnum,
+        SecondEnum,
+        ThirdEnum,
+    }
+}

--- a/src/JsonPatch.Tests/JsonPatch.Tests.csproj
+++ b/src/JsonPatch.Tests/JsonPatch.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -43,6 +44,12 @@
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bcl.AsyncInterfaces.7.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MSTest.TestFramework.3.1.1\lib\net462\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MSTest.TestFramework.3.1.1\lib\net462\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
@@ -78,17 +85,14 @@
         <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
+    <Otherwise />
   </Choose>
   <ItemGroup>
     <Compile Include="AttributePathHelperTests.cs" />
     <Compile Include="Entitys\EnumEntity.cs" />
     <Compile Include="Entitys\ArrayEntity.cs" />
     <Compile Include="Entitys\ComplexEntity.cs" />
+    <Compile Include="Entitys\EnumNullableEntity.cs" />
     <Compile Include="Entitys\ListEntity.cs" />
     <Compile Include="Entitys\DictionaryEntity.cs" />
     <Compile Include="Entitys\SimpleEntity.cs" />
@@ -132,6 +136,14 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/JsonPatch.Tests/JsonPatchDocumentTests.cs
+++ b/src/JsonPatch.Tests/JsonPatchDocumentTests.cs
@@ -3,6 +3,10 @@ using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using JsonPatch.Tests.Entities;
 using JsonPatch;
+using System.Runtime;
+using System.Text.Json.Serialization;
+using JsonPatch.Tests.Entitys;
+using System;
 
 namespace JsonPatch.Tests
 {
@@ -229,6 +233,46 @@ namespace JsonPatch.Tests
 
             //Assert
             Assert.AreEqual("baz", entity.Foo);
+        }
+
+        [TestMethod]
+        public void ApplyUpdate_ReplaceOperation_BadEnum()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<EnumEntity>();
+            var entity = new EnumEntity();
+            var badEnumValue = "Garbage";
+
+            //Act
+            patchDocument.Replace(nameof(EnumEntity.Foo), badEnumValue);
+            var myException = Assert.ThrowsException<JsonPatchOperationException>(() => patchDocument.ApplyUpdatesTo(entity));
+
+            //Assert
+            Assert.AreEqual(myException.Message, "Failed to set value at path \"/Foo\" while performing \"replace\" operation: Requested value 'Garbage' was not found.");
+            Assert.AreEqual(myException.operationType, JsonPatchOperationType.replace);
+            Assert.AreEqual(myException.path, $"/{nameof(EnumEntity.Foo)}");
+            Assert.AreEqual(myException.entityType, entity.Foo.GetType());
+            Assert.AreEqual(myException.value, badEnumValue);
+        }
+
+        [TestMethod]
+        public void ApplyUpdate_ReplaceOperation_BadNullableEnum()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<EnumNullableEntity>();
+            var entity = new EnumNullableEntity();
+            var badEnumValue = "Garbage";
+
+            //Act
+            patchDocument.Replace(nameof(EnumNullableEntity.Foo), badEnumValue);
+            var myException = Assert.ThrowsException<JsonPatchOperationException>(() => patchDocument.ApplyUpdatesTo(entity));
+
+            //Assert
+            Assert.AreEqual(myException.Message, "Failed to set value at path \"/Foo\" while performing \"replace\" operation: Error converting value \"Garbage\" to type 'System.Nullable`1[JsonPatch.Tests.Entitys.SampleNullableEnum]'. Path '', line 1, position 9.");
+            Assert.AreEqual(myException.operationType, JsonPatchOperationType.replace);
+            Assert.AreEqual(myException.path, $"/{nameof(EnumNullableEntity.Foo)}");
+            Assert.AreEqual(myException.entityType, typeof(EnumNullableEntity).GetProperty(nameof(EnumNullableEntity.Foo)).PropertyType);
+            Assert.AreEqual(myException.value, badEnumValue);
         }
 
         #endregion

--- a/src/JsonPatch.Tests/PathHelperTests.cs
+++ b/src/JsonPatch.Tests/PathHelperTests.cs
@@ -86,7 +86,7 @@ namespace JsonPatch.Tests
             Assert.IsTrue(pathComponents[0].IsCollection);
             Assert.AreEqual("5", pathComponents[1].Name);
             Assert.IsInstanceOfType(pathComponents[1], typeof(CollectionIndexPathComponent));
-            Assert.AreEqual(5, ((CollectionIndexPathComponent) pathComponents[1]).CollectionIndex);
+            Assert.AreEqual(5, ((CollectionIndexPathComponent)pathComponents[1]).CollectionIndex);
             Assert.AreEqual(typeof(string), pathComponents[1].ComponentType);
         }
 
@@ -438,7 +438,7 @@ namespace JsonPatch.Tests
         public void SetValueFromPath_InvalidPath_ThrowsException()
         {
             //act
-            _resolver.SetValueFromPath(typeof(SimpleEntity), "",  new SimpleEntity { }, null, JsonPatchOperationType.add);
+            _resolver.SetValueFromPath(typeof(SimpleEntity), "", new SimpleEntity { }, null, JsonPatchOperationType.add);
         }
 
         [TestMethod]
@@ -488,7 +488,7 @@ namespace JsonPatch.Tests
 
             //act
             _resolver.SetValueFromPath(typeof(SimpleEntity), "/Foo", entity, "New Value", JsonPatchOperationType.replace);
-            
+
             //assert
             Assert.AreEqual("New Value", entity.Foo);
         }
@@ -559,7 +559,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual(2, entity.Foo.Count);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_ReplaceIndexOutOfBounds_ThrowsException()
         {
             //Arrange
@@ -572,7 +572,7 @@ namespace JsonPatch.Tests
             _resolver.SetValueFromPath(typeof(ArrayEntity), "/Foo/2", entity, "Element Two Updated", JsonPatchOperationType.replace);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_AddArrayValue_ThrowsError()
         {
             //Arrange
@@ -588,13 +588,13 @@ namespace JsonPatch.Tests
             // NotSupportedException: Collection was of a fixed size.
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_RemoveArrayValue_ThrowsException()
         {
             //Arrange
             var entity = new ArrayEntity
             {
-                Foo = new string[] {"Element One", "Element Two", "Element Three"}
+                Foo = new string[] { "Element One", "Element Two", "Element Three" }
             };
 
             //act
@@ -605,7 +605,7 @@ namespace JsonPatch.Tests
         }
 
         #endregion
-        
+
         #region List tests
 
         [TestMethod]
@@ -643,7 +643,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual(3, entity.Foo.Count);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_AddToNullList_ThrowsException()
         {
             //Arrange
@@ -706,7 +706,7 @@ namespace JsonPatch.Tests
         }
 
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_RemoveIndexOutOfBounds_ThrowsException()
         {
             //Arrange
@@ -729,7 +729,7 @@ namespace JsonPatch.Tests
             //Arrange
             var entity = new DictionaryEntity<string>
             {
-                Foo = new Dictionary<string, string> {{"key1", "Element One"}, {"key2", "Element Two"},}
+                Foo = new Dictionary<string, string> { { "key1", "Element One" }, { "key2", "Element Two" }, }
             };
 
             //act
@@ -747,7 +747,7 @@ namespace JsonPatch.Tests
             //Arrange
             var entity = new DictionaryEntity<int>
             {
-                Foo = new Dictionary<int, string> {{1, "Element One"}, {2, "Element Two"},}
+                Foo = new Dictionary<int, string> { { 1, "Element One" }, { 2, "Element Two" }, }
             };
 
             //act
@@ -765,7 +765,7 @@ namespace JsonPatch.Tests
             //Arrange
             var entity = new DictionaryEntity<int>
             {
-                Foo = new Dictionary<int, string> {{1, "Element One"}, {2, "Element Two"},}
+                Foo = new Dictionary<int, string> { { 1, "Element One" }, { 2, "Element Two" }, }
             };
 
             //act
@@ -776,7 +776,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual(3, entity.Foo.Count);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_AddDictionaryValue_ThrowsForExistingKey()
         {
             //Arrange
@@ -822,7 +822,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual(2, entity.Foo.Count);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_AddToNullDictionary_ThrowsException()
         {
             //Arrange
@@ -851,7 +851,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual("New Value", entity.Bar.Foo);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_NullParent_ThrowsException()
         {
             //arrange
@@ -918,7 +918,7 @@ namespace JsonPatch.Tests
             Assert.IsNull(entity.Qux[0].Foo);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_AddToListItemOutOfBounds_ThrowsException()
         {
             //arrange
@@ -953,7 +953,7 @@ namespace JsonPatch.Tests
             Assert.AreEqual("Element One - Updated", entity.Foo.Foo[0]);
         }
 
-        [TestMethod, ExpectedException(typeof(JsonPatchException))]
+        [TestMethod, ExpectedException(typeof(JsonPatchOperationException))]
         public void SetValueFromPath_AddToNestedArray_ThrowsException()
         {
             //arrange

--- a/src/JsonPatch.Tests/PathHelperTests.cs
+++ b/src/JsonPatch.Tests/PathHelperTests.cs
@@ -584,7 +584,7 @@ namespace JsonPatch.Tests
             //act
             _resolver.SetValueFromPath(typeof(ArrayEntity), "/Foo/2", entity, "Element Three", JsonPatchOperationType.add);
 
-            // Arrays should not support resizing. Expect JsonPatchException with an inner exception of type
+            // Arrays should not support resizing. Expect JsonPatchOperationException with an inner exception of type
             // NotSupportedException: Collection was of a fixed size.
         }
 
@@ -600,7 +600,7 @@ namespace JsonPatch.Tests
             //act
             _resolver.SetValueFromPath(typeof(ArrayEntity), "/Foo/1", entity, null, JsonPatchOperationType.remove);
 
-            // Arrays should not support resizing. Expect JsonPatchException with an inner exception of type
+            // Arrays should not support resizing. Expect JsonPatchOperationException with an inner exception of type
             // NotSupportedException: Collection was of a fixed size
         }
 

--- a/src/JsonPatch.Tests/packages.config
+++ b/src/JsonPatch.Tests/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net48" />
+  <package id="MSTest.TestAdapter" version="3.1.1" targetFramework="net48" />
+  <package id="MSTest.TestFramework" version="3.1.1" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />


### PR DESCRIPTION
Add new JsonPatchOperationException and implement it in tests and BaseResolver. Add TestAdapter and TestFramework packages to use Assert.ThrowsException