### PR TITLE
Ignore Casing of Letters When Patching Enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ JsonPatch example:
 
 var jsonPatchSettings = new JsonPatchSettings
 {
-	PathResolver = new ExactCasePropertyPathResolver(new JsonValueConverter())
+    PathResolver = new ExactCasePropertyPathResolver(new JsonValueConverter())
 };
 
 ```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ The path specified in the patch request can be resolved to a different property 
 E.g. the ExactCasePropertyPathResolver will match a property based on an exact match
 
 ```C#
+//JsonPatch
+var jsonPatchSettings = new JsonPatchSettings
+{
+	PathResolver = new ExactCasePropertyPathResolver(new JsonValueConverter())
+};
 
+//JsonPatchCore
 JsonPatchSettings.Options = new JsonPatchOptions
 {
     PathResolver = new ExactCasePropertyPathResolver(new JsonValueConverter()),

--- a/README.md
+++ b/README.md
@@ -41,14 +41,19 @@ The path specified in the patch request can be resolved to a different property 
 
 E.g. the ExactCasePropertyPathResolver will match a property based on an exact match
 
+JsonPatch example:
 ```C#
-//JsonPatch
+
 var jsonPatchSettings = new JsonPatchSettings
 {
 	PathResolver = new ExactCasePropertyPathResolver(new JsonValueConverter())
 };
 
-//JsonPatchCore
+```
+
+JsonPatchCore example:
+```C#
+
 JsonPatchSettings.Options = new JsonPatchOptions
 {
     PathResolver = new ExactCasePropertyPathResolver(new JsonValueConverter()),
@@ -56,6 +61,7 @@ JsonPatchSettings.Options = new JsonPatchOptions
 };
 
 ```
+
 
 Now the request 
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ JsonPatchSettings.Options = new JsonPatchOptions
 
 ```
 
-
 Now the request 
 
     PATCH /my/data HTTP/1.1

--- a/src/JsonPatch.Tests/JsonPatchDocumentTests.cs
+++ b/src/JsonPatch.Tests/JsonPatchDocumentTests.cs
@@ -287,6 +287,59 @@ namespace JsonPatch.Tests
             Assert.AreEqual(SampleEnum.FirstEnum, entity.Foo);
         }
 
+        [TestMethod]
+        public void ApplyUpdate_ReplaceOperation_LowercaseEnum()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<EnumEntity>();
+            var entity = new EnumEntity
+            {
+                Foo = SampleEnum.FirstEnum
+            };
+
+            //Act
+            patchDocument.Replace(nameof(EnumEntity.Foo), "secondenum");
+            patchDocument.ApplyUpdatesTo(entity);
+
+            //Assert
+            Assert.AreEqual(entity.Foo, SampleEnum.SecondEnum);
+        }
+
+        [TestMethod]
+        public void ApplyUpdate_ReplaceOperation_LowercaseNullableEnum()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<EnumNullableEntity>();
+            var entity = new EnumNullableEntity
+            {
+                Foo = SampleEnum.FirstEnum
+            };
+
+            //Act
+            patchDocument.Replace(nameof(EnumNullableEntity.Foo), "secondenum");
+            patchDocument.ApplyUpdatesTo(entity);
+
+            //Assert
+            Assert.AreEqual(entity.Foo, SampleEnum.SecondEnum);
+        }
+
+        [TestMethod]
+        public void ApplyUpdate_ReplaceOperation_LowercaseNullableEnum_Null()
+        {
+            //Arrange
+            var patchDocument = new JsonPatchDocument<EnumNullableEntity>();
+            var entity = new EnumNullableEntity
+            {
+                Foo = null
+            };
+
+            //Act
+            patchDocument.Replace(nameof(EnumNullableEntity.Foo), "secondenum");
+            patchDocument.ApplyUpdatesTo(entity);
+
+            //Assert
+            Assert.AreEqual(entity.Foo, SampleEnum.SecondEnum);
+        }
         #endregion
 
         #region Move Operation

--- a/src/JsonPatch/JsonPatchDocument.cs
+++ b/src/JsonPatch/JsonPatchDocument.cs
@@ -1,13 +1,8 @@
-﻿using System;
+﻿using JsonPatch.Formatting;
+using JsonPatch.Paths.Resolvers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using JsonPatch;
-using JsonPatch.Paths;
-using JsonPatch.Paths.Resolvers;
-using JsonPatch.Formatting;
 
 namespace JsonPatch
 {

--- a/src/JsonPatch/JsonValueConverter.cs
+++ b/src/JsonPatch/JsonValueConverter.cs
@@ -21,13 +21,13 @@ namespace JsonPatch
             }
             else if (type.IsEnum)
             {
-                return Enum.Parse(type, value.ToString());
+                return Enum.Parse(type, value.ToString(), true);
             }
             else if (Nullable.GetUnderlyingType(type)?.IsEnum == true)
             {
                 if (value == null)
                     return null;
-                return Enum.Parse(Nullable.GetUnderlyingType(type), value.ToString());
+                return Enum.Parse(Nullable.GetUnderlyingType(type), value.ToString(), true);
             }
             else
             {

--- a/src/JsonPatchCore/JsonValueConverter.cs
+++ b/src/JsonPatchCore/JsonValueConverter.cs
@@ -31,13 +31,13 @@ namespace JsonPatch
             }
             else if (type.IsEnum)
             {
-                return Enum.Parse(type, value.ToString());
+                return Enum.Parse(type, value.ToString(), true);
             }
             else if (Nullable.GetUnderlyingType(type)?.IsEnum == true)
             {
                 if (value == null)
                     return null;
-                return Enum.Parse(Nullable.GetUnderlyingType(type), value.ToString());
+                return Enum.Parse(Nullable.GetUnderlyingType(type), value.ToString(), true);
             }
             else
             {


### PR DESCRIPTION
- Change how enums are parsed so that casing of letters does not matter. 
- Tweak readme to explain differences in changing PathResolver for JsonPatch and JsonPatchCore
- Cleaned up 1 file's unused references (this was somehow missed in my last PR).