### PR TITLE
Support extending the BaseResolver

### DIFF
--- a/src/JsonPatch.Common/Paths/Resolvers/AttributePropertyPathResolver.cs
+++ b/src/JsonPatch.Common/Paths/Resolvers/AttributePropertyPathResolver.cs
@@ -24,7 +24,7 @@ namespace JsonPatch.Paths.Resolvers
         /// <param name="parentType"></param>
         /// <param name="component"></param>
         /// <returns></returns>
-        internal override PropertyInfo GetProperty(Type parentType, string component)
+        public override PropertyInfo GetProperty(Type parentType, string component)
         {
             var dataMemberPropertyMatch = parentType.GetProperties().FirstOrDefault(p =>
             {

--- a/src/JsonPatch.Common/Paths/Resolvers/BaseResolver.cs
+++ b/src/JsonPatch.Common/Paths/Resolvers/BaseResolver.cs
@@ -24,7 +24,13 @@ namespace JsonPatch.Paths.Resolvers
             this.converter = converter;
         }
 
-        internal abstract PropertyInfo GetProperty(Type parentType, string component);
+        /// <summary>
+        /// Get the property reference for a component
+        /// </summary>
+        /// <param name="parentType"></param>
+        /// <param name="component"></param>
+        /// <returns></returns>
+        public abstract PropertyInfo GetProperty(Type parentType, string component);
 
         /// <summary>
         /// Get components of a path

--- a/src/JsonPatch.Common/Paths/Resolvers/CaseInsensitivePropertyPathResolver.cs
+++ b/src/JsonPatch.Common/Paths/Resolvers/CaseInsensitivePropertyPathResolver.cs
@@ -22,7 +22,7 @@ namespace JsonPatch.Paths.Resolvers
         /// <param name="parentType"></param>
         /// <param name="component"></param>
         /// <returns></returns>
-        internal override PropertyInfo GetProperty(Type parentType, string component)
+        public override PropertyInfo GetProperty(Type parentType, string component)
         {
             return parentType.GetProperty(component,
                 BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);

--- a/src/JsonPatch.Common/Paths/Resolvers/ExactCasePropertyPathResolver.cs
+++ b/src/JsonPatch.Common/Paths/Resolvers/ExactCasePropertyPathResolver.cs
@@ -22,7 +22,7 @@ namespace JsonPatch.Paths.Resolvers
         /// <param name="parentType"></param>
         /// <param name="component"></param>
         /// <returns></returns>
-        internal override PropertyInfo GetProperty(Type parentType, string component)
+        public override PropertyInfo GetProperty(Type parentType, string component)
         {
             return parentType.GetProperty(component);
         }

--- a/src/JsonPatch.Common/Paths/Resolvers/FlexiblePathResolver.cs
+++ b/src/JsonPatch.Common/Paths/Resolvers/FlexiblePathResolver.cs
@@ -28,7 +28,7 @@ namespace JsonPatch.Paths.Resolvers
         /// <param name="parentType"></param>
         /// <param name="component"></param>
         /// <returns></returns>
-        internal override PropertyInfo GetProperty(Type parentType, string component)
+        public override PropertyInfo GetProperty(Type parentType, string component)
         {
             var property = (new AttributePropertyPathResolver(converter).GetProperty(parentType, component) ?? 
                 new ExactCasePropertyPathResolver(converter).GetProperty(parentType, component)) ?? 


### PR DESCRIPTION
Allowing external libraries override the GetProperty attribute so that different rules for determining the property can be implemented in external libraries. 